### PR TITLE
Очистка /tmp/toff при прерывании выполнения

### DIFF
--- a/scripts/xkeen
+++ b/scripts/xkeen
@@ -37,6 +37,9 @@ get_state_arg() {
 
 # Импортируем модули
 . "$script_dir/.xkeen/import.sh"
+
+# Маркер /tmp/toff отключает curl_timeout — снимаем при прерывании
+trap 'rm -f /tmp/toff; exit 1' INT TERM
 	
 xkeen_info() {
     # Проверяем версию XKeen


### PR DESCRIPTION
При запуске `xkeen` с флагом `-toff` создаётся маркер `/tmp/toff`, который отключает таймаут `curl` через пустой `curl_timeout` в `import.sh`. В штатном flow маркер удаляется в `delete_tmp` в самом конце.

Если пользователь прерывает выполнение по Ctrl+C до завершения, маркер остаётся на месте. `/tmp` на Keenetic это tmpfs, поэтому маркер живёт до перезагрузки роутера. Все последующие запуски `xkeen` в том же uptime используют пустой `curl_timeout` и зависают на медленных каналах.

Добавлен `trap 'rm -f /tmp/toff; exit 1' INT TERM` после загрузки `import.sh`. Полный `delete_tmp` в trap не вызывается намеренно: он также удаляет `xray_bak`/`mihomo_bak`, и при прерывании во время `xkeen -ux` это могло бы оставить роутер без рабочего ядра.