### PR TITLE
Атомарная подмена ipset через swap вместо flush + restore

### DIFF
--- a/scripts/_xkeen/02_install/05_install_geoipset.sh
+++ b/scripts/_xkeen/02_install/05_install_geoipset.sh
@@ -53,11 +53,17 @@ load_geoipset() {
     set="$1"
     file="$2"
     family="$3"
+    tmp="${set}_tmp"
 
+    # Заполняем tmp; основной набор подменяется только после успешного restore
     ipset create "$set" hash:net family "$family" -exist
-    ipset flush "$set"
+    ipset create "$tmp" hash:net family "$family" -exist
+    ipset flush "$tmp"
 
-    [ -f "$file" ] && awk '/^[0-9a-fA-F]/ {print "add '"$set"' "$1}' "$file" | ipset restore -exist
+    if [ -f "$file" ] && awk '/^[0-9a-fA-F]/ {print "add '"$tmp"' "$1}' "$file" | ipset restore -exist; then
+        ipset swap "$set" "$tmp"
+    fi
+    ipset destroy "$tmp"
 }
 
 install_geoipset() {

--- a/scripts/_xkeen/02_install/07_install_register/04_register_init.sh
+++ b/scripts/_xkeen/02_install/07_install_register/04_register_init.sh
@@ -483,12 +483,19 @@ load_user_ipset_family() {
     set_name="$1"
     family="$2"
     addr_regex="$3"
+    tmp="${set_name}_tmp"
 
+    # Заполняем tmp; основной набор подменяется только после успешного pipeline
     ipset create "$set_name" hash:net family "$family" -exist
-    ipset flush "$set_name"
-    sed -e 's/\r$//' -e 's/#.*//' -e '/^[[:space:]]*$/d' "$file_ip_exclude" |
-    grep -Eo "$addr_regex" |
-    awk -v s="$set_name" '{print "add "s" "$1}' | ipset restore -exist
+    ipset create "$tmp" hash:net family "$family" -exist
+    ipset flush "$tmp"
+
+    if sed -e 's/\r$//' -e 's/#.*//' -e '/^[[:space:]]*$/d' "$file_ip_exclude" |
+       grep -Eo "$addr_regex" |
+       awk -v s="$tmp" '{print "add "s" "$1}' | ipset restore -exist; then
+        ipset swap "$set_name" "$tmp"
+    fi
+    ipset destroy "$tmp"
 }
 
 # Функция загрузки пользовательских исключений в ipset
@@ -1574,11 +1581,17 @@ load_ipset() {
     set="$1"
     file="$2"
     family="$3"
+    tmp="${set}_tmp"
 
+    # Заполняем tmp; основной набор подменяется только после успешного restore
     ipset create "$set" hash:net family "$family" -exist
-    ipset flush "$set"
+    ipset create "$tmp" hash:net family "$family" -exist
+    ipset flush "$tmp"
 
-    [ -f "$file" ] && sed -e 's/\r$//' -e 's/#.*//' -e '/^[[:space:]]*$/d' "$file" | awk '{print "add '"$set"' "$1}' | ipset restore -exist
+    if [ -f "$file" ] && sed -e 's/\r$//' -e 's/#.*//' -e '/^[[:space:]]*$/d' "$file" | awk '{print "add '"$tmp"' "$1}' | ipset restore -exist; then
+        ipset swap "$set" "$tmp"
+    fi
+    ipset destroy "$tmp"
 }
 
 apply_fd_limit() {


### PR DESCRIPTION
Функции `load_geoipset` (`05_install_geoipset.sh`), `load_ipset` и `load_user_ipset_family` (`04_register_init.sh`) обновляют ipset через `flush` + `restore`:

- `ipset flush <set>` очищает основной набор;
- pipe из `awk`/`sed`/`grep` собирает строки `add` и подаёт их в `ipset restore`.

Между `flush` и завершением `restore` основной набор пуст, а `iptables` уже руководствуется им через `match-set`. Для `geo_exclude` это окно приводит к leak'у: трафик к российским IP, который должен идти direct, на доли секунды попадает в xray и уходит через VPN. Если `restore` падает (битый файл, нехватка памяти, ошибка `awk`/`sed`), основной набор остаётся пустым до следующего успешного обновления. Лик сохраняется до следующего `xkeen -gips` или `xkeen -restart`.

---

## Что изменено

Все три функции переведены на паттерн «load to tmp + atomic swap»:

- набор наполняется во временном `<set>_tmp`;
- при успешной загрузке выполняется `ipset swap <set> <set>_tmp`;
- временный набор уничтожается через `ipset destroy`.

`ipset swap` атомарен на уровне ядра: при нём `iptables` ни на одну инструкцию не видит пустой набор. На любую ошибку загрузки старый набор остаётся целым.