### PR TITLE
Кэширование lsmod в get_modules

### DIFF
--- a/scripts/_xkeen/02_install/07_install_register/04_register_init.sh
+++ b/scripts/_xkeen/02_install/07_install_register/04_register_init.sh
@@ -612,8 +612,18 @@ check_dns_config() {
 }
 file_dns=$(check_dns_config)
 
+# Кэш списка загруженных модулей; is_module_loaded читает его без форков
+_loaded_modules=""
+
+_refresh_modules_cache() {
+    _loaded_modules=" $(lsmod 2>/dev/null | awk '{print $1}' | tr '\n' ' ') "
+}
+
 is_module_loaded() {
-    lsmod | awk '{print $1}' | grep -qx "$1"
+    case "$_loaded_modules" in
+        *" $1 "*) return 0 ;;
+        *) return 1 ;;
+    esac
 }
 
 # Загрузка модулей
@@ -632,11 +642,13 @@ load_modules() {
 
 # Обработка модулей и портов
 get_modules() {
+    _refresh_modules_cache
     load_modules xt_comment.ko
     load_modules xt_TPROXY.ko
     load_modules xt_socket.ko
     load_modules xt_multiport.ko
     load_modules xt_dscp.ko
+    _refresh_modules_cache  # подхватить только что insmod-нутые модули
 
     if ! is_module_loaded xt_comment; then
         log_error_router "Модуль xt_comment не загружен"


### PR DESCRIPTION
`get_modules` вызывает `is_module_loaded` 10 раз за каждый старт прокси: 5 раз внутри `load_modules` (для каждого `xt_*.ko`) и ещё 5 раз в проверках после загрузки. Текущая реализация:

```sh
is_module_loaded() {
    lsmod | awk '{print $1}' | grep -qx "$1"
}
```

На каждую проверку три fork+exec. Итого ~30 процессов за каждый `xkeen -restart`.

Список модулей кэшируется в `_loaded_modules` одним вызовом `lsmod`. `is_module_loaded` работает по кэшу через `case` без форков:

```sh
_refresh_modules_cache() {
    _loaded_modules=" $(lsmod 2>/dev/null | awk '{print $1}' | tr '\n' ' ') "
}

is_module_loaded() {
    case "$_loaded_modules" in
        *" $1 "*) return 0 ;;
        *) return 1 ;;
    esac
}
```

`get_modules` обновляет кэш до `load_modules` и ещё раз после, чтобы insmod-нутые модули попали в кэш до проверок. Итого 6 процессов вместо ~30.

Поведение `is_module_loaded` не меняется: `case " $loaded " in *" $name "*` с обрамляющими пробелами совпадает с `grep -qx`, целые слова матчатся, подстроки нет (имя `xt` не матчит модуль `xt_comment`). Парсинг первого столбца `lsmod | awk '{print $1}'` идентичен исходной реализации, busybox-совместим.