### PR TITLE
cleanup: пропущенный $ в rm в register_xkeen

### DIFF
--- a/scripts/_xkeen/02_install/07_install_register/02_register_xkeen.sh
+++ b/scripts/_xkeen/02_install/07_install_register/02_register_xkeen.sh
@@ -105,7 +105,8 @@ register_xkeen_initd() {
     if choice_backup_xkeen; then
         rm -f "$source_main_backup" "$source_start_backup"
     fi
-    rm -f "$old_initd_file" "old_start_file" "$pre_initd_file"
+    # Пропущенный $ ломал очистку легаси S99xkeenstart при апгрейде с 1.x
+    rm -f "$old_initd_file" "$old_start_file" "$pre_initd_file"
 }
 
 # Миграция скрипта


### PR DESCRIPTION
Заметил мелкую опечатку в register_xkeen_initd.

На строке 108 в команде rm пропущен `$` перед `old_start_file`:

```
rm -f "$old_initd_file" "old_start_file" "$pre_initd_file"
```

При апгрейде с 1.x, если `mv` на :67 не успел перенести легаси `${initd_dir}/S99xkeenstart` (abort, permission errors между mv и rm), `rm` пытался удалить файл буквально с именем `old_start_file` в текущей директории. Реальный S99xkeenstart оставался в `/opt/etc/init.d` и переживал апгрейд.

Добавил `$`, теперь rm удаляет правильный файл.
