### PR TITLE
perf: один opkg list-installed вместо 11 форков на старт

### DIFF
--- a/scripts/_xkeen/01_info/02_info_packages.sh
+++ b/scripts/_xkeen/01_info/02_info_packages.sh
@@ -1,13 +1,17 @@
+# Кэшируем список установленных пакетов один раз вместо opkg-форка на каждую проверку
+_packages_cache=$(opkg list-installed 2>/dev/null)
+
 # Функция для проверки наличия необходимых пакетов
 info_packages() {
     package_name="$1"
-    
-    # Проверяем, установлен ли пакет
-    if opkg list-installed | grep -q "^$package_name "; then
-        package_status="installed"
-    else
-        package_status="not_installed"
-    fi
+
+    # Newline-prefix эмулирует якорь "^pkg ", чтобы libc не матчил libcurl
+    case "
+$_packages_cache" in
+        *"
+$package_name "*) package_status="installed" ;;
+        *) package_status="not_installed" ;;
+    esac
 }
 
 # Проверка наличия пакета "coreutils-uname"


### PR DESCRIPTION
На Hopper SE arm64 1.3 GHz `xkeen -status` отрабатывает с заметной паузой ~0.2с. Глянул в `02_info_packages.sh`: файл source'ится при каждом CLI-вызове и проверяет 11 пакетов через `opkg list-installed | grep -q`. На каждую команду это 11 fork+exec opkg плюс 11 grep.

Сделал один read списка в `_packages_cache`, проверки через `case` с newline-prefix (эквивалент `grep -q "^pkg "`, без substring-collision: `libc` не матчит `libcurl`).

На Hopper SE: `xkeen -status` 0.203s → 0.090s (-56%). Список зависимостей определяется идентично main.
