### PR TITLE
fix: проверка refilter-файлов после удаления GeoSite/GeoIP

### DIFF
--- a/scripts/_xkeen/01_info/06_info_console.sh
+++ b/scripts/_xkeen/01_info/06_info_console.sh
@@ -43,7 +43,8 @@ logs_delete_configs_info_console() {
 
 logs_delete_geosite_info_console() {
     echo -e "  ${yellow}Проверка${reset} выполнения операции"
-    for file in "geosite_antifilter.dat" "geosite_v2fly.dat" "geosite_zkeen.dat"; do
+    # antifilter переименован в refilter в install/delete, имя verification отстало
+    for file in "geosite_refilter.dat" "geosite_v2fly.dat" "geosite_zkeen.dat"; do
         [ ! -f "$geo_dir/$file" ]
         print_log_status $? "Файл $file отсутствует в директории '$geo_dir'" "Файл $file не удален"
     done
@@ -51,7 +52,7 @@ logs_delete_geosite_info_console() {
 
 logs_delete_geoip_info_console() {
     echo -e "  ${yellow}Проверка${reset} выполнения операции"
-    for file in "geoip_antifilter.dat" "geoip_v2fly.dat" "geoip_zkeenip.dat"; do
+    for file in "geoip_refilter.dat" "geoip_v2fly.dat" "geoip_zkeenip.dat"; do
         [ ! -f "$geo_dir/$file" ]
         print_log_status $? "Файл $file отсутствует в директории '$geo_dir'" "Файл $file не удален"
     done


### PR DESCRIPTION
Заметил странную вещь в коде. В `06_info_console.sh` функции `logs_delete_geosite_info_console` и `logs_delete_geoip_info_console` после `rm` геофайлов проверяют `geosite_antifilter.dat` и `geoip_antifilter.dat`, а install (`04_install_geofile.sh:70,112`) и delete (`delete_geofile.sh`) работают с `*_refilter.dat`.

Имя `*_antifilter.dat` нигде в проекте не создаётся, поэтому verification всегда возвращает 0, реальные сбои `rm` тонут в сообщении «удалено успешно».

Заменил на актуальное `*_refilter.dat`. `grep -rn 'antifilter' scripts/` после правки чист, имя нигде в install/delete/detect не задействовано, это изолированная опечатка только в verification.
