### PR TITLE
fix: автоустановка GeoIPSET в xkeen -gips без TTY

### DIFF
--- a/scripts/_xkeen/02_install/05_install_geoipset.sh
+++ b/scripts/_xkeen/02_install/05_install_geoipset.sh
@@ -70,31 +70,40 @@ install_geoipset() {
     action="$1"
 
     if [ "$action" = "init" ]; then
-        while true; do
-            printf "\n  Желаете исключить российские IP-адреса из проксирования?\n\n"
-            printf "     1. Загрузить и установить в исключения IP-подсети России (${yellow}GeoIPSET${reset})\n"
-            printf "     0. Пропустить\n\n"
-            printf "  Ваш выбор: "
-            read -r choice
+        # Без TTY (cron, ssh -T) read получает EOF, default-case крутит while true
+        # бесконечно: процесс висит в R-state с CPU-spin. Дефолтим выбор на "1"
+        # (установить), потому что xkeen -gips из cron это типичный
+        # non-interactive caller, где пользователь явно ожидает установку.
+        if [ ! -t 0 ]; then
+            printf "  Не интерактивный режим (нет TTY): автоматическая установка GeoIPSET\n"
+            bypass_cron_geoipset=false
+        else
+            while true; do
+                printf "\n  Желаете исключить российские IP-адреса из проксирования?\n\n"
+                printf "     1. Загрузить и установить в исключения IP-подсети России (${yellow}GeoIPSET${reset})\n"
+                printf "     0. Пропустить\n\n"
+                printf "  Ваш выбор: "
+                read -r choice
 
-            case "$choice" in
-                0)
-                    printf "  Пропуск установки списков GeoIPSET\n\n"
+                case "$choice" in
+                    0)
+                        printf "  Пропуск установки списков GeoIPSET\n\n"
 
-                    if [ ! -f "$ru_exclude_ipv4" ] && [ ! -f "$ru_exclude_ipv6" ]; then
-                        bypass_cron_geoipset=true
-                    fi
-                    return 0
-                    ;;
-                1)
-                    bypass_cron_geoipset=false
-                    break
-                    ;;
-                *)
-                    printf "  Неверный ввод. Пожалуйста, введите 1 или 0.\n"
-                    ;;
-            esac
-        done
+                        if [ ! -f "$ru_exclude_ipv4" ] && [ ! -f "$ru_exclude_ipv6" ]; then
+                            bypass_cron_geoipset=true
+                        fi
+                        return 0
+                        ;;
+                    1)
+                        bypass_cron_geoipset=false
+                        break
+                        ;;
+                    *)
+                        printf "  Неверный ввод. Пожалуйста, введите 1 или 0.\n"
+                        ;;
+                esac
+            done
+        fi
     fi
 
     if ip -4 addr show 2>/dev/null | grep -q "inet " && command -v iptables >/dev/null 2>&1; then


### PR DESCRIPTION
`xkeen -gips` зависает при запуске без TTY (cron, `ssh -T`, отвалившаяся ssh-сессия): процесс висит в R-state с CPU-spin до таймаута.

Сценарий: `install_geoipset init` в `05_install_geoipset.sh` входит в интерактивный `while true; do read -r choice; case ... esac; done`. Без TTY `read -r` получает EOF, `choice` пустой, попадает в default `*)`, печатает «Неверный ввод» и крутит while true.

Перед циклом проверяется `[ ! -t 0 ]`. Если stdin не TTY, дефолтим выбор на "1" (установить) и пропускаем prompt: `bypass_cron_geoipset=false`, дальше идёт обычный код установки. С TTY поведение прежнее, интерактивный prompt остаётся.

Дефолт "1" а не "0", потому что типичный non-interactive caller это `xkeen -gips` из cron, где пользователь явно хочет установку. Если бы дефолтили на "0" (skip), команда из cron молча ничего бы не делала - это маскировало бы проблему вместо фикса.

Где это меняет поведение, а где нет:

- `xkeen -gips` (line 1106-1112) интерактивно: без изменений.
- `xkeen -gips` без TTY: раньше виснет, теперь молча устанавливает.
- `xkeen -i` (line 151) с TTY: без изменений.
- `xkeen -i` без TTY: раньше виснет, теперь автоустановка GeoIPSET. Полный flow `-i` всё равно не предназначен для non-interactive (там много других `choice_*` функций), но конкретно `install_geoipset init` теперь не блокирует.

На Hopper SE: `ssh -T 'xkeen -gips </dev/null'` без правки виснет 20-30 минут до таймаута, с правкой выходит штатно с установленным GeoIPSET за время загрузки списков.

Альтернатива через явный флаг `-y`/`--yes` была бы чище архитектурно, но требует обработки в xkeen entry point. Текущий вариант минимальный и закрывает основной сценарий busy-loop.
