### PR TITLE
xkeen: отвязка от ssh-сессии при non-interactive -restart/-start/-stop

### DIFF
--- a/scripts/xkeen
+++ b/scripts/xkeen
@@ -27,7 +27,30 @@ add_chmod_init() {
 for arg in "$@"; do
     [ "$arg" = "-toff" ] && touch "/tmp/toff"
     [ "$arg" = "-restart" ] && apply="restart"
+    case "$arg" in
+        -restart|-start|-stop) detach_eligible=true ;;
+    esac
 done
+
+# Self-detach в новую session/pgid когда вызвали без TTY (ssh без -t, cron, CGI)
+# чтобы форсированный обрыв caller-сессии не убивал начальные проверки.
+# Подробности в commit-message. XKEEN_FOREGROUND=1 отключает детач для callers
+# требующих синхронной семантики (скрипты с && cleanup).
+if [ -n "$detach_eligible" ] && [ -z "$XKEEN_DETACHED" ] \
+   && [ ! -t 0 ] && [ ! -t 1 ] && [ -z "$XKEEN_FOREGROUND" ]; then
+    export XKEEN_DETACHED=1
+    [ -d /opt/var/log ] || mkdir -p /opt/var/log
+    log=/opt/var/log/xkeen-detached.log
+    {
+        echo
+        echo "=== $(date '+%F %T') $0 $* ==="
+    } >>"$log"
+    start-stop-daemon -S -b -n "xkdtch.$$" \
+        -x "$0" -- "$@" \
+        >>"$log" 2>&1
+    echo "  Запуск в фоновом режиме, лог: $log" >&2
+    exit 0
+fi
 
 get_state_arg() {
     if [ "$1" = "on" ] || [ "$1" = "off" ]; then


### PR DESCRIPTION
Принёс на подумать. Сам не уверен что это правильное решение, может вы сразу видите проще.
Если решите что не подходит - смело закрывайте, или если есть идея как сделать чище или взглянуть на проблему с другой стороны - буду рад услышать)

## Мой кейс

У меня настроена автоматизация которая делает `ssh root@router 'xkeen -restart'` из удалённого скрипта. Несколько раз ловил такое: скрипт по таймауту обрывал ssh-клиента ровно в момент когда xkeen ещё на этапе начальных проверок (`validate_xkeen_json`, `killall` старого xray, `clean_firewall`). Старый xray уже убит, новый не запущен, firewall наполовину собран. VPN ложился пока я руками не сделаю `xkeen -restart` с консоли.

## Что нашёл

Когда sshd закрывает PTY-master при потере TCP-сокета, ядро TTY-driver рассылает SIGHUP по всей session-pgid. `xkeen` (обёртка), `S05xkeen restart` (subprocess) и `proxy_start`, все в этой группе и помирают раньше чем xray вообще успеет fork'нуться.

Цепочка процессов в момент SIGHUP:

```
sshd-shell (pgid=A)
 └ xkeen          (pgid=A) ← обёртка
   └ S05xkeen     (pgid=A)
     └ proxy_start (pgid=A) ← здесь умирает до fork xray
```

## Что пробовал

Сначала добавил `nohup` в сам `proxy_start`. Не помогло: nohup защищает только уже-запущенный xray, а начальные проверки сидят в caller-pgid и продолжают помирать раньше чем дело дойдёт до запуска xray.

Поэтому переключился на отвязку на уровне обёртки `xkeen`, до начала любой работы.

## Что предлагаю

В начале dispatch'а обёртки проверяю: вызов без терминала (нет tty на stdin и stdout) и не выставлен `XKEEN_FOREGROUND`, тогда re-exec'аю себя через `start-stop-daemon -b` в новой session/pgid и сразу выхожу. Реальная работа продолжается отвязанно, SIGHUP по caller-pgid её уже не достаёт.

Гейт детача:

```sh
[ ! -t 0 ] && [ ! -t 1 ]
```

Одновременная проверка stdin и stdout, чтобы случай вроде `xkeen -restart | tee log` из консоли не уезжал в фон (там stdin tty есть).

Re-exec:

```sh
start-stop-daemon -S -b -n "xkdtch.$$" -x "$0" -- "$@"
```

Уникальный `-n` обходит коллизию pre-fork procfs-scan с уже-работающим xkeen, `-b` делает `setsid()` + detach.

Опт-аут через `XKEEN_FOREGROUND=1` для тех кому нужна синхронная семантика (скрипты с `&& cleanup`).

Output фоновой операции пишется в `/opt/var/log/xkeen-detached.log`. Caller получает в stderr одну строку:

```
Запуск в фоновом режиме, лог: /opt/var/log/xkeen-detached.log
```

и `exit 0` за <300 мс.

## Что меня смущает в этом решении

Семантика для вызовов без tty становится асинхронной:

```sh
ssh root@router 'xkeen -restart && echo OK'
```

Напечатает `OK` мгновенно, не дождавшись настоящего рестарта. Для своего кейса считаю это приемлемым (у меня всё равно ssh может оборваться в любой момент), но для основной аудитории это может быть сюрприз. `XKEEN_FOREGROUND=1` как escape, но всё равно поведение по умолчанию меняется.

## Что проверил

Прогнал у себя на KN-3812 (Hopper SE, aarch64), BusyBox 1.37.0, Hybrid, xray, ipv6 включён.

1. Из консоли `xkeen -restart` (прямая сессия с tty): синхронно, цветные сообщения видны, как раньше.

2. Нормальный non-interactive вызов:
   ```sh
   time ssh root@router 'xkeen -restart'
   # 0.27s; через несколько секунд xray поднят, режим Hybrid,
   # цепочка iptables xkeen активна, в логе полный output
   ```

3. Обрыв ssh на 1-й секунде (раньше xray не запускался, теперь работает):
   ```sh
   ssh root@router 'xkeen -restart' & sleep 1; kill -9 $!
   sleep 8
   ssh root@router 'pgrep xray'   # PID
   ssh root@router 'cat /proc/$(pgrep xray)/status | grep PPid'
   # PPid: 1  (отвязан)
   ```

4. Обрыв ssh на 3-й секунде (раньше работало по совпадению, теперь гарантированно):
   ```sh
   ssh root@router 'xkeen -restart' & sleep 3; kill -9 $!
   sleep 8
   ssh root@router 'pgrep xray'   # PID
   ```

5. `XKEEN_FOREGROUND=1` сохраняет старую синхронность:
   ```sh
   time ssh root@router 'XKEEN_FOREGROUND=1 xkeen -restart'
   # ~13s, output виден, как до патча
   ```

6. cron `xkeen -ug` с автоматическим перезапуском не задет: `-ug` идёт через `$initd_file restart` напрямую, мимо обёртки.

7. `sh -n scripts/xkeen` после правки.