### PR TITLE
perf: active-probe вместо sleep в proxy_start и proxy_stop

### DIFF
--- a/scripts/_xkeen/02_install/07_install_register/04_register_init.sh
+++ b/scripts/_xkeen/02_install/07_install_register/04_register_init.sh
@@ -1829,7 +1829,13 @@ proxy_start() {
                         ;;
                     *) log_error_terminal "Неизвестный прокси-клиент: ${yellow}$name_client${reset}" ;;
                 esac
-                sleep 2
+                _probe_attempt=0
+                while [ "$_probe_attempt" -lt 60 ]; do
+                    proxy_status && break
+                    _probe_attempt=$((_probe_attempt + 1))
+                    usleep 50000
+                done
+                unset _probe_attempt
                 if proxy_status; then
                     [ "$mode_proxy" != "Other" ] && configure_firewall
                     [ "$iptables_supported" = "true" ] && [ -f "$ru_exclude_ipv4" ] && load_ipset geo_exclude "$ru_exclude_ipv4" inet

--- a/scripts/_xkeen/02_install/07_install_register/04_register_init.sh
+++ b/scripts/_xkeen/02_install/07_install_register/04_register_init.sh
@@ -1884,10 +1884,16 @@ proxy_stop() {
         while [ "$attempt" -le "$start_attempts" ]; do
             clean_firewall
             killall -q "$name_client" 2>/dev/null
-            sleep 1
+            _stop_attempt=0
+            while [ "$_stop_attempt" -lt 30 ]; do
+                pidof "$name_client" >/dev/null 2>&1 || break
+                _stop_attempt=$((_stop_attempt + 1))
+                usleep 50000
+            done
+            unset _stop_attempt
             if pidof "$name_client" >/dev/null 2>&1; then
-                sleep 2
                 killall -q -9 "$name_client" 2>/dev/null
+                usleep 200000
             fi
             if ! proxy_status; then
                 echo -e "  Прокси-клиент ${red}остановлен${reset}"


### PR DESCRIPTION
Поковырял `xkeen -restart` на тему ускорения, нашёл несколько независимых моментов, оформил как серию атомарных PR. Каждый можно мерджить отдельно.

- #42 параллельная загрузка load_ipset через фоновые задания
- #43 файловый кэш для get_xray_transparent_inbounds
- #44 раскрытие переменных в шелле вместо вызова sed в inject_var
- #45 батчинг iptables-restore вместо ~150 серийных вызовов
- #46 active-probe вместо sleep 5 в холодном старте netfilter hook
- #47 параллельная загрузка геофайлов в install_geo*

---

В `proxy_start` после `start-stop-daemon -S -b -m -x ...` стоит `sleep 2`. В `proxy_stop` после `killall -q` стоит `sleep 1`, затем при живом pid ещё `sleep 2` перед SIGKILL.

На KN-3812 (Hopper SE, aarch64) xray поднимает оба inbound (vless 443/tcp + hy2 8443/udp) за <100ms, на SIGTERM умирает за 30-50ms. Заменил все три sleep на проб через `usleep 50000` с потолками 3с / 1.5с / 0.2с. Аварийные сценарии остаются прежними, попадаем в `Не удалось запустить` / `Не удалось остановить`.

`usleep` доступен в busybox 1.37 на Entware. `sleep 0.05` busybox не понимает.

KN-3812, Hybrid + xray, 2 inbound, ipv6, `xkeen -restart`:
```
before: 8.05s avg (3 прогона)
after:  5.95s avg (3 прогона)
```
