### PR TITLE
perf: параллельная загрузка load_ipset через background jobs

### DIFF
--- a/scripts/_xkeen/02_install/07_install_register/04_register_init.sh
+++ b/scripts/_xkeen/02_install/07_install_register/04_register_init.sh
@@ -1832,9 +1832,12 @@ proxy_start() {
                 sleep 2
                 if proxy_status; then
                     [ "$mode_proxy" != "Other" ] && configure_firewall
-                    [ "$iptables_supported" = "true" ] && [ -f "$ru_exclude_ipv4" ] && load_ipset geo_exclude "$ru_exclude_ipv4" inet
-                    [ "$ip6tables_supported" = "true" ] && [ -f "$ru_exclude_ipv6" ] && load_ipset geo_exclude6 "$ru_exclude_ipv6" inet6
-                    load_user_ipset
+                    _pids=""
+                    [ "$iptables_supported" = "true" ] && [ -f "$ru_exclude_ipv4" ] && { load_ipset geo_exclude "$ru_exclude_ipv4" inet & _pids="$_pids $!"; }
+                    [ "$ip6tables_supported" = "true" ] && [ -f "$ru_exclude_ipv6" ] && { load_ipset geo_exclude6 "$ru_exclude_ipv6" inet6 & _pids="$_pids $!"; }
+                    load_user_ipset & _pids="$_pids $!"
+                    [ -n "$_pids" ] && wait $_pids
+                    unset _pids
                     echo -e "  Прокси-клиент ${green}запущен${reset} в режиме ${light_blue}${mode_proxy}${reset}"
                     if [ -n "$api_policy_json" ]; then
                         if echo "$api_policy_json" | jq --arg policy "$name_policy" -e 'any(.[]; .description | ascii_downcase == $policy)' > /dev/null; then


### PR DESCRIPTION
Поковырял `xkeen -restart` на тему ускорения, нашёл несколько независимых моментов, оформил как серию атомарных PR. Каждый можно мерджить отдельно.

- #41 active-probe вместо sleep в proxy_start и proxy_stop
- #43 файловый кэш для get_xray_transparent_inbounds
- #44 раскрытие переменных в шелле вместо вызова sed в inject_var
- #45 батчинг iptables-restore вместо ~150 серийных вызовов
- #46 active-probe вместо sleep 5 в холодном старте netfilter hook
- #47 параллельная загрузка геофайлов в install_geo*

---

В `proxy_start` три серийных `load_ipset` (geo_exclude ipv4 + geo_exclude6 + load_user_ipset). Каждый внутри это `awk` поток в `ipset restore`. Наборы независимы (разные имена, разные семейства), атомарная подмена из #34 работает на каждый set отдельно. Завернул в `&` + `wait`, busybox sh поддерживает.

KN-3812, Hopper SE, Hybrid, ru_exclude ~50k подсетей. Замер шёл вместе с active-probe в proxy_stop, изолированно по `time` снять не удалось. Из суммарных ~1.2с этому патчу приписываю ~0.3с (max вместо суммы трёх вызовов).
