### PR TITLE
perf: file-cache для get_xray_transparent_inbounds

### DIFF
--- a/scripts/_xkeen/02_install/07_install_register/04_register_init.sh
+++ b/scripts/_xkeen/02_install/07_install_register/04_register_init.sh
@@ -722,28 +722,47 @@ get_modules() {
 }
 
 # Получение transparent inbound'ов Xray
-get_xray_transparent_inbounds() {
-    for file in "$directory_xray_config"/*.json; do
-        [ -f "$file" ] || continue
+_invalidate_inbounds_cache() {
+    rm -f /tmp/xkeen-inbounds-cache
+}
 
-        strip_json_comments "$file" |
-        jq -r --arg file "$file" '
-            .inbounds[]? |
-            select(
-                (.protocol == "dokodemo-door" or .protocol == "tunnel") and
-                ((.settings.followRedirect? // false) == true)
-            ) |
-            (.streamSettings.sockopt.tproxy? // "") as $tproxy |
-            select($tproxy == "" or $tproxy == "redirect" or $tproxy == "tproxy") |
-            [
-                (if $tproxy == "tproxy" then "tproxy" else "redirect" end),
-                (.port // ""),
-                (.settings.network // ""),
-                (.tag // ""),
-                $file
-            ] | @tsv
-        ' 2>/dev/null
-    done
+get_xray_transparent_inbounds() {
+    cache_file="/tmp/xkeen-inbounds-cache"
+    cache_valid=0
+    if [ -f "$cache_file" ]; then
+        newer=$(find "$directory_xray_config" -maxdepth 1 -name '*.json' -newer "$cache_file" 2>/dev/null | head -n 1)
+        [ -z "$newer" ] && cache_valid=1
+    fi
+    if [ "$cache_valid" = "1" ]; then
+        cat "$cache_file"
+        return 0
+    fi
+    cache_tmp="${cache_file}.tmp.$$"
+    {
+        for file in "$directory_xray_config"/*.json; do
+            [ -f "$file" ] || continue
+
+            strip_json_comments "$file" |
+            jq -r --arg file "$file" '
+                .inbounds[]? |
+                select(
+                    (.protocol == "dokodemo-door" or .protocol == "tunnel") and
+                    ((.settings.followRedirect? // false) == true)
+                ) |
+                (.streamSettings.sockopt.tproxy? // "") as $tproxy |
+                select($tproxy == "" or $tproxy == "redirect" or $tproxy == "tproxy") |
+                [
+                    (if $tproxy == "tproxy" then "tproxy" else "redirect" end),
+                    (.port // ""),
+                    (.settings.network // ""),
+                    (.tag // ""),
+                    $file
+                ] | @tsv
+            ' 2>/dev/null
+        done
+    } > "$cache_tmp"
+    mv "$cache_tmp" "$cache_file"
+    cat "$cache_file"
 }
 
 get_xray_port_by_mode() {
@@ -1727,6 +1746,7 @@ info_health_binary() {
 proxy_start() {
     start_manual="$1"
     if [ "$start_manual" = "on" ] || [ "$start_auto" = "on" ]; then
+        _invalidate_inbounds_cache
         apply_ipv6_state
         get_ipver_support
         info_health_binary


### PR DESCRIPTION
Поковырял `xkeen -restart` на тему ускорения, нашёл несколько независимых моментов, оформил как серию атомарных PR. Каждый можно мерджить отдельно.

- #41 active-probe вместо sleep в proxy_start и proxy_stop
- #42 параллельная загрузка load_ipset через фоновые задания
- #44 раскрытие переменных в шелле вместо вызова sed в inject_var
- #45 батчинг iptables-restore вместо ~150 серийных вызовов
- #46 active-probe вместо sleep 5 в холодном старте netfilter hook
- #47 параллельная загрузка геофайлов в install_geo*

---

`get_xray_port_by_mode` и `get_xray_network_by_mode` зовутся в `proxy_start` 4 раза подряд (`redirect`/`tproxy` × `port`/`network`). Каждый внутри через дочерний шелл вызывает `get_xray_transparent_inbounds`, которая форкает `strip_json_comments | jq` на каждый файл в `$directory_xray_config`. На 6 json'ах это 8 jq-форков на каждый restart за одними и теми же данными.

Кэш в shell-переменной не работает: caller'ы зовут функцию через `port=$(get_xray_port_by_mode redirect)`, переменные в родительский шелл не пробрасываются. Сделал файловый кэш в `/tmp/xkeen-inbounds-cache` с инвалидацией по mtime через `find -newer`, атомарный `mv` через `.tmp.$$`. Сбрасывается через `_invalidate_inbounds_cache` в начале `proxy_start` для случая когда файл переписан тем же содержимым (mtime не меняется).

KN-3812:
```
before (patches 1+2): 5.64s avg
after  (+ кэш):       5.01s avg
```

`time` user-component упал с 1.30s до 1.06s.
