### PR TITLE
perf: shell parameter expansion вместо sed-fork в inject_var

### DIFF
--- a/scripts/_xkeen/02_install/07_install_register/04_register_init.sh
+++ b/scripts/_xkeen/02_install/07_install_register/04_register_init.sh
@@ -1047,7 +1047,7 @@ EOL
         local name="$1"
         local val="$2"
         local safe_val
-        safe_val=$(printf '%s\n' "$val" | sed "s/'/'\\\\''/g")
+        safe_val="${val//\'/\'\\\'\'}"
         printf "%s='%s'\n" "$name" "$safe_val" >> "$file_netfilter_hook"
     }
 


### PR DESCRIPTION
Поковырял `xkeen -restart` на тему ускорения, нашёл несколько независимых моментов, оформил как серию атомарных PR. Каждый можно мерджить отдельно.

- #41 active-probe вместо sleep в proxy_start и proxy_stop
- #42 параллельная загрузка load_ipset через фоновые задания
- #43 файловый кэш для get_xray_transparent_inbounds
- #45 батчинг iptables-restore вместо ~150 серийных вызовов
- #46 active-probe вместо sleep 5 в холодном старте netfilter hook
- #47 параллельная загрузка геофайлов в install_geo*

---

`inject_var` в `register_xkeen` зовётся ~40 раз для подстановки переменных в netfilter-хук. На каждый вызов форкается `printf | sed`. Заменил на `${val//\'/\'\\\'\'}`, busybox sh поддерживает. `md5sum /opt/etc/ndm/netfilter.d/proxy.sh` идентичен до и после. 40 fork+exec убраны.

KN-3812:
```
before (patches 1+2+3): 5.01s avg
after  (+ inject_var):  4.78s avg
```
