### PR TITLE
perf: active-probe вместо sleep 5 в cold-start netfilter hook

### DIFF
--- a/scripts/_xkeen/02_install/07_install_register/04_register_init.sh
+++ b/scripts/_xkeen/02_install/07_install_register/04_register_init.sh
@@ -1528,7 +1528,13 @@ else
             "$name_client" >/dev/null 2>&1 &
         ;;
     esac
-    sleep 5
+    _probe=0
+    while [ "$_probe" -lt 60 ]; do
+        pidof "$name_client" >/dev/null 2>&1 && break
+        _probe=$((_probe + 1))
+        usleep 100000
+    done
+    unset _probe
     rm -f "/tmp/xkeen_starting.lock"
     if pidof "$name_client" >/dev/null; then
         restart_script "$@"


### PR DESCRIPTION
Поковырял `xkeen -restart` на тему ускорения, нашёл несколько независимых моментов, оформил как серию атомарных PR. Каждый можно мерджить отдельно.

- #41 active-probe вместо sleep в proxy_start и proxy_stop
- #42 параллельная загрузка load_ipset через фоновые задания
- #43 файловый кэш для get_xray_transparent_inbounds
- #44 раскрытие переменных в шелле вместо вызова sed в inject_var
- #45 батчинг iptables-restore вместо ~150 серийных вызовов
- #47 параллельная загрузка геофайлов в install_geo*

---

Тот же паттерн что в #41, но в else-ветке `proxy.sh` (срабатывает при холодном старте, когда хук дёргается до того как xray жив). Сейчас фиксированный `sleep 5` после фоновой ssd-команды, потом `restart_script "$@"`. Заменил на проб `pidof` через `usleep 100000` с потолком 60 итераций (6с). При неудаче запуска xray на следующей строке ловим `if pidof ...` и `exit 1`.

KN-3812, `killall xray` и затем `sh /opt/etc/ndm/netfilter.d/proxy.sh`:
```
before (sleep 5):  5.67s avg (3 прогона)
after  (probe):    1.00s avg (3 прогона)
```
