### PR TITLE
perf: параллельная загрузка геофайлов в install_geosite/install_geoip/install_geoipset

### DIFF
--- a/scripts/_xkeen/02_install/04_install_geofile.sh
+++ b/scripts/_xkeen/02_install/04_install_geofile.sh
@@ -71,35 +71,43 @@ process_geo_file() {
 install_geosite() {
     mkdir -p "$geo_dir" || { echo "Ошибка: Не удалось создать директорию $geo_dir"; exit 1; }
 
-    # Установка GeoSite Re:filter
+    local zkeen_datfile=""
+    if [ "$install_zkeen_geosite" = "true" ] || [ "$update_zkeen_geosite" = "true" ]; then
+        zkeen_datfile="geosite_zkeen.dat"
+        if [ -L "$geo_dir/geosite_zkeen.dat" ]; then
+            zkeen_datfile="zkeen.dat"
+        elif [ -L "$geo_dir/zkeen.dat" ]; then
+            zkeen_datfile="geosite_zkeen.dat"
+        elif [ -f "$geo_dir/zkeen.dat" ] && ! [ -f "$geo_dir/geosite_zkeen.dat" ]; then
+            zkeen_datfile="zkeen.dat"
+        fi
+    fi
+
+    # Параллельная загрузка независимых геофайлов
+    local _pids=""
     if [ "$install_refilter_geosite" = "true" ] || [ "$update_refilter_geosite" = "true" ]; then
         process_geo_file "$refilter_url" "geosite_refilter.dat" \
-            "GeoSite Re:filter" "$update_refilter_geosite"
+            "GeoSite Re:filter" "$update_refilter_geosite" &
+        _pids="$_pids $!"
     fi
 
-    # Установка GeoSite V2Fly
     if [ "$install_v2fly_geosite" = "true" ] || [ "$update_v2fly_geosite" = "true" ]; then
         process_geo_file "$v2fly_url" "geosite_v2fly.dat" \
-            "GeoSite V2Fly" "$update_v2fly_geosite"
+            "GeoSite V2Fly" "$update_v2fly_geosite" &
+        _pids="$_pids $!"
     fi
 
-    # Установка GeoSite ZKeen
-    if [ "$install_zkeen_geosite" = "true" ] || [ "$update_zkeen_geosite" = "true" ]; then
-        local datfile="geosite_zkeen.dat"
+    if [ -n "$zkeen_datfile" ]; then
+        process_geo_file "$zkeen_url" "$zkeen_datfile" \
+            "GeoSite ZKeen" "$update_zkeen_geosite" &
+        _pids="$_pids $!"
+    fi
 
-        if [ -L "$geo_dir/geosite_zkeen.dat" ]; then
-            datfile="zkeen.dat"
-        elif [ -L "$geo_dir/zkeen.dat" ]; then
-            datfile="geosite_zkeen.dat"
-        elif [ -f "$geo_dir/zkeen.dat" ] && ! [ -f "$geo_dir/geosite_zkeen.dat" ]; then
-            datfile="zkeen.dat"
-        fi
+    [ -n "$_pids" ] && wait $_pids
 
-        process_geo_file "$zkeen_url" "$datfile" \
-            "GeoSite ZKeen" "$update_zkeen_geosite"
-
-        # Создание симлинков для совместимости
-        if [ "$datfile" = "geosite_zkeen.dat" ]; then
+    # Симлинки zkeen после успешной загрузки
+    if [ -n "$zkeen_datfile" ]; then
+        if [ "$zkeen_datfile" = "geosite_zkeen.dat" ]; then
             rm -f "$geo_dir/zkeen.dat"
             ln -sf "$geo_dir/geosite_zkeen.dat" "$geo_dir/zkeen.dat"
         else
@@ -113,35 +121,43 @@ install_geosite() {
 install_geoip() {
     mkdir -p "$geo_dir" || { echo "Ошибка: Не удалось создать директорию $geo_dir"; exit 1; }
 
-    # Установка GeoIP Re:filter
+    local zkeenip_datfile=""
+    if [ "$install_zkeenip_geoip" = "true" ] || [ "$update_zkeenip_geoip" = "true" ]; then
+        zkeenip_datfile="geoip_zkeenip.dat"
+        if [ -L "$geo_dir/geoip_zkeenip.dat" ]; then
+            zkeenip_datfile="zkeenip.dat"
+        elif [ -L "$geo_dir/zkeenip.dat" ]; then
+            zkeenip_datfile="geoip_zkeenip.dat"
+        elif [ -f "$geo_dir/zkeenip.dat" ] && ! [ -f "$geo_dir/geoip_zkeenip.dat" ]; then
+            zkeenip_datfile="zkeenip.dat"
+        fi
+    fi
+
+    # Параллельная загрузка независимых геофайлов
+    local _pids=""
     if [ "$install_refilter_geoip" = "true" ] || [ "$update_refilter_geoip" = "true" ]; then
         process_geo_file "$refilterip_url" "geoip_refilter.dat" \
-            "GeoIP Re:filter" "$update_refilter_geoip"
+            "GeoIP Re:filter" "$update_refilter_geoip" &
+        _pids="$_pids $!"
     fi
 
-    # Установка GeoIP V2Fly
     if [ "$install_v2fly_geoip" = "true" ] || [ "$update_v2fly_geoip" = "true" ]; then
         process_geo_file "$v2flyip_url" "geoip_v2fly.dat" \
-            "GeoIP V2Fly" "$update_v2fly_geoip"
+            "GeoIP V2Fly" "$update_v2fly_geoip" &
+        _pids="$_pids $!"
     fi
 
-    # Установка GeoIP ZKeenIP
-    if [ "$install_zkeenip_geoip" = "true" ] || [ "$update_zkeenip_geoip" = "true" ]; then
-        local datfile="geoip_zkeenip.dat"
+    if [ -n "$zkeenip_datfile" ]; then
+        process_geo_file "$zkeenip_url" "$zkeenip_datfile" \
+            "GeoIP ZKeenIP" "$update_zkeenip_geoip" &
+        _pids="$_pids $!"
+    fi
 
-        if [ -L "$geo_dir/geoip_zkeenip.dat" ]; then
-            datfile="zkeenip.dat"
-        elif [ -L "$geo_dir/zkeenip.dat" ]; then
-            datfile="geoip_zkeenip.dat"
-        elif [ -f "$geo_dir/zkeenip.dat" ] && ! [ -f "$geo_dir/geoip_zkeenip.dat" ]; then
-            datfile="zkeenip.dat"
-        fi
+    [ -n "$_pids" ] && wait $_pids
 
-        process_geo_file "$zkeenip_url" "$datfile" \
-            "GeoIP ZKeenIP" "$update_zkeenip_geoip"
-
-        # Создание симлинков для совместимости
-        if [ "$datfile" = "geoip_zkeenip.dat" ]; then
+    # Симлинки zkeenip после успешной загрузки
+    if [ -n "$zkeenip_datfile" ]; then
+        if [ "$zkeenip_datfile" = "geoip_zkeenip.dat" ]; then
             rm -f "$geo_dir/zkeenip.dat"
             ln -sf "$geo_dir/geoip_zkeenip.dat" "$geo_dir/zkeenip.dat"
         else

--- a/scripts/_xkeen/02_install/05_install_geoipset.sh
+++ b/scripts/_xkeen/02_install/05_install_geoipset.sh
@@ -106,15 +106,24 @@ install_geoipset() {
         fi
     fi
 
+    local do_v4=0 do_v6=0
     if ip -4 addr show 2>/dev/null | grep -q "inet " && command -v iptables >/dev/null 2>&1; then
-        [ "$action" != "init" ] && [ ! -f "$ru_exclude_ipv4" ] && return 0
-        install_geoipset_lst "$geoipv4_url" "$ru_exclude_ipv4" "IPv4 (IPSet)" "ipv4"
-        load_geoipset geo_exclude "$ru_exclude_ipv4" inet
+        if [ "$action" = "init" ] || [ -f "$ru_exclude_ipv4" ]; then
+            do_v4=1
+        fi
+    fi
+    if ip -6 addr show 2>/dev/null | grep -q "inet6 " && command -v ip6tables >/dev/null 2>&1; then
+        if [ "$action" = "init" ] || [ -f "$ru_exclude_ipv6" ]; then
+            do_v6=1
+        fi
     fi
 
-    if ip -6 addr show 2>/dev/null | grep -q "inet6 " && command -v ip6tables >/dev/null 2>&1; then
-        [ "$action" != "init" ] && [ ! -f "$ru_exclude_ipv6" ] && return 0
-        install_geoipset_lst "$geoipv6_url" "$ru_exclude_ipv6" "IPv6 (IPSet)" "ipv6"
-        load_geoipset geo_exclude6 "$ru_exclude_ipv6" inet6
-    fi
+    # Параллельная загрузка независимых списков
+    local _pids=""
+    [ "$do_v4" = "1" ] && { install_geoipset_lst "$geoipv4_url" "$ru_exclude_ipv4" "IPv4 (IPSet)" "ipv4" & _pids="$_pids $!"; }
+    [ "$do_v6" = "1" ] && { install_geoipset_lst "$geoipv6_url" "$ru_exclude_ipv6" "IPv6 (IPSet)" "ipv6" & _pids="$_pids $!"; }
+    [ -n "$_pids" ] && wait $_pids
+
+    [ "$do_v4" = "1" ] && load_geoipset geo_exclude "$ru_exclude_ipv4" inet
+    [ "$do_v6" = "1" ] && load_geoipset geo_exclude6 "$ru_exclude_ipv6" inet6
 }


### PR DESCRIPTION
Поковырял `xkeen -restart` на тему ускорения, нашёл несколько независимых моментов, оформил как серию атомарных PR. Каждый можно мерджить отдельно.

- #41 active-probe вместо sleep в proxy_start и proxy_stop
- #42 параллельная загрузка load_ipset через фоновые задания
- #43 файловый кэш для get_xray_transparent_inbounds
- #44 раскрытие переменных в шелле вместо вызова sed в inject_var
- #45 батчинг iptables-restore вместо ~150 серийных вызовов
- #46 active-probe вместо sleep 5 в холодном старте netfilter hook

---

В `install_geosite`, `install_geoip` и `install_geoipset` независимые `process_geo_file` / `install_geoipset_lst` вызываются последовательно. Все цели независимы: разные адреса, разные временные и итоговые файлы. Завернул в `&` + `wait`, как в #42.

`process_geo_file` использует `local temp_file=$(mktemp)`, общего состояния между параллельными вызовами нет, `mv` в итоговый путь атомарный для каждого файла. Симлинки zkeen вынесены за `wait`, чтобы `ln -sf` не пересекался с `mv` внутри параллельного `process_geo_file`.

KN-3812 (Hopper SE, aarch64), все 6 наборов установлены:
```
before (serial):    15.7s avg (3 прогона: 18 / 15 / 14)
after  (parallel):  13.0s avg (3 прогона: 13 / 12 / 14)
```
