### PR TITLE
fix: cold-boot race с co-installed netfilter.d-хуками

### DIFF
--- a/scripts/_xkeen/02_install/07_install_register/04_register_init.sh
+++ b/scripts/_xkeen/02_install/07_install_register/04_register_init.sh
@@ -997,6 +997,7 @@ configure_firewall() {
     cat > "$file_netfilter_hook" <<'EOL'
 #!/bin/sh
 # XKeen: Auto-generated file. DO NOT EDIT!
+[ -f /tmp/xkeen_ready ] || exit 0
 EOL
 
     # Securely inject variables into the script
@@ -1844,6 +1845,9 @@ proxy_start() {
         fi
         if proxy_status; then
             echo -e "  Прокси-клиент уже ${green}запущен${reset}"
+            # Marker до configure_firewall: тот завершается `sh proxy.sh`,
+            # gate в хуке читает /tmp/xkeen_ready.
+            touch "/tmp/xkeen_ready"
             [ "$mode_proxy" != "Other" ] && configure_firewall
             if [ "$start_manual" = "on" ]; then
                 log_error_terminal "Не удалось запустить ${yellow}$name_client${reset}, так как он уже запущен"
@@ -1891,6 +1895,8 @@ proxy_start() {
                 done
                 unset _probe_attempt
                 if proxy_status; then
+                    # См. alive-branch: marker до configure_firewall.
+                    touch "/tmp/xkeen_ready"
                     [ "$mode_proxy" != "Other" ] && configure_firewall
                     _pids=""
                     [ "$iptables_supported" = "true" ] && [ -f "$ru_exclude_ipv4" ] && { load_ipset geo_exclude "$ru_exclude_ipv4" inet & _pids="$_pids $!"; }
@@ -1929,8 +1935,33 @@ proxy_start() {
     fi
 }
 
+# Активная проба готовности окружения вместо sleep $start_delay.
+# Ждём ndmc, default route и insmod-ability xt_TPROXY (deps ndm
+# подгружает асинхронно уже после ndmc-ready). $start_delay сохранён
+# как safety cap (FAQ #12).
+wait_for_ready() {
+    _max=$(( ${start_delay:-60} * 2 ))
+    _attempt=0
+    _probe_ko="$directory_os_modules/xt_TPROXY.ko"
+    while [ "$_attempt" -lt "$_max" ]; do
+        if ndmc -c "show version" >/dev/null 2>&1 \
+           && ip route show default 2>/dev/null | grep -q '^default'; then
+            # .ko отсутствует (не TProxy/Hybrid), уже загружен, либо insmod удался
+            if [ ! -f "$_probe_ko" ] \
+               || grep -q '^xt_TPROXY ' /proc/modules 2>/dev/null \
+               || insmod "$_probe_ko" >/dev/null 2>&1; then
+                return 0
+            fi
+        fi
+        usleep 500000
+        _attempt=$((_attempt + 1))
+    done
+    return 0
+}
+
 # Остановка прокси-клиента
 proxy_stop() {
+    rm -f "/tmp/xkeen_ready"
     if ! proxy_status; then
         echo -e "  Прокси-клиент ${red}не запущен${reset}"
         cleanup_fd_monitor
@@ -1973,7 +2004,7 @@ case "$1" in
         if [ -z "$2" ]; then
             [ "$start_auto" != "on" ] && exit 0
             log_info_router "Подготовка к запуску прокси-клиента"
-            nohup sh -c "sleep $start_delay && $0 restart" >/dev/null 2>&1 &
+            nohup "$0" cold_start >/dev/null 2>&1 &
             touch "/tmp/xkeen_coldstart.lock"
             exit 0
         fi
@@ -1993,6 +2024,12 @@ case "$1" in
         fi
         ;;
     restart) proxy_stop; proxy_start "$2" ;;
+    cold_start)
+        # Re-spawn в чистый S05xkeen: sh-функции (wait_for_ready) не
+        # наследуются через nohup sh -c, поэтому пробу зовём отсюда.
+        wait_for_ready
+        proxy_start ""
+        ;;
     *) echo -e "  Команды: ${green}start${reset} | ${red}stop${reset} | ${yellow}restart${reset} | status" ;;
 esac
 


### PR DESCRIPTION
Поставил рядом `nfqws2-keenetic` и заметил что после ребута роутера VPN полминуты лежит. Стал копаться. Оказалось, nfqws2 на старте трогает фаервол, и от этого срабатывает `proxy.sh` ещё до того как до него доходит `S05xkeen`. Хук видит что xray не запущен, лезет в else-ветку и пытается всё поднять сам, но `xt_TPROXY` к этому моменту ещё не загружен, `iptables-restore` молча давится на TPROXY-правиле, в итоге xray есть, а правил нет. Через `start_delay` приходит штатный `S05xkeen`, прибивает первый xray и поднимает второй уже как надо. Получаем лишний рестарт и минуту простоя.

Решил пофиксить по двум направлениям, по отдельности ни одно не помогает.

**1. Чтобы хук не запускал xray сам.** Первой строкой в `proxy.sh` теперь маркер-чек `/tmp/xkeen_ready`. Маркер ставится в `proxy_start` перед `configure_firewall`, снимается в `proxy_stop`. Пока xkeen не сказал «я готов», хук тихо выходит и в else-ветку не лезет.

**2. Чтобы вместо `sleep $start_delay` была активная проба.** В `case start)` теперь форкается новый `cold_start)`, в котором ждём три условия: `ndmc` отвечает, default route на месте, `xt_TPROXY` грузится (либо уже там, либо `insmod` проходит, иначе по `lsmod` не отличить «вот-вот будет» от «не нужен этому конфигу»). Как только готово, сразу `proxy_start`, без слепой паузы. Потолок цикла `start_delay * 2` итераций по 0.5s, чтоб на корнер-кейсе не зависнуть.

В итоге xray стартует один раз, правила накатываются с первой попытки, простой между «есть default route» и «слушает inbound» сократился примерно на 22 секунды.

## Бенч

KN-3812 (Hopper SE), Hybrid + xray, 2 inbound, nfqws2-keenetic 0.9.5, ipv6 on. Один cold reboot на версию.

```
                              upstream    patched    delta
загрузка модуля TPROXY        51.91s      35.88s     -16.0s
правила xkeen применены       53.90s      37.09s     -16.8s
xray слушает inbound          86.29s      64.43s     -21.9s
повторный fork xray           да          нет
```

## Что проверил

1. Cold reboot: xray pid стабилен, 47 правил, набор байт-в-байт совпадает с upstream после стабилизации.
2. `xkeen -restart` с tty: синхронно, цветные сообщения как раньше.
3. `xkeen -ipv6 off && xkeen -restart && sh /opt/etc/ndm/netfilter.d/proxy.sh; echo $?` → 0. То же с `-ipv6 on`.
4. `sh -n` после правки.