### PR TITLE
fix(install): use latin 'cc' in ghproxy URL

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -56,7 +56,7 @@ download_xkeen_release() {
         return 0
     fi
 
-    if curl -kfLo "$archive_name" --connect-timeout 10 -m 15 "https://ghproxy.сс/$url"; then
+    if curl -kfLo "$archive_name" --connect-timeout 10 -m 15 "https://ghproxy.cc/$url"; then
         return 0
     fi
 
@@ -75,7 +75,7 @@ download_release_fix() {
         return 0
     fi
 
-    if curl -kfLo "$target_file" --connect-timeout 10 -m 15 "https://ghproxy.сс/$release_fix_url"; then
+    if curl -kfLo "$target_file" --connect-timeout 10 -m 15 "https://ghproxy.cc/$release_fix_url"; then
         return 0
     fi
 


### PR DESCRIPTION
В коммите 68cb44f в install.sh в URL `https://ghproxy.сс/` две буквы `с` кириллические (U+0441). Домен не резолвится, fallback на прокси №2 не работает.

<img width="693" height="406" alt="image" src="https://github.com/user-attachments/assets/6bfd1e47-22e7-4b76-bad5-2142df54e08f" />

Поправил на `ghproxy.cc` латиницей.
