### PR TITLE
fix: per-call mirror fallback в downloader'ах

### DIFF
--- a/scripts/_xkeen/02_install/04_install_geofile.sh
+++ b/scripts/_xkeen/02_install/04_install_geofile.sh
@@ -11,51 +11,23 @@ process_geo_file() {
         return 1
     fi
 
-    test_github
-
-    local temp_file=$(mktemp)
     local min_size=24576  # 24 KB
-
-    download() {
-        eval curl $curl_extra --connect-timeout 10 $curl_timeout -fL -o "$temp_file" "$1" >/dev/null 2>&1
-        return $?
-    }
 
     printf "  Загрузка %s...\n" "$display_name"
 
-    if [ "$use_direct" = "true" ]; then
-        :
-    else
-        url="$gh_proxy/$url"
-    fi
-
-    download "$url"
-    if [ $? -eq 0 ]; then
-        :
-    else
-        rm -f "$temp_file"
-        printf "  ${red}Ошибка${reset}: не удалось загрузить %s\n" "$display_name"
+    if ! fetch_with_mirrors "$url" "$geo_dir/$filename" "$min_size"; then
+        case "$_last_error" in
+            size)
+                printf "  ${red}Ошибка${reset}: загруженный файл слишком мал (%s bytes) или повреждён\n  Невозможно обновить. Оставляем старый файл\n\n" "$_last_size"
+                ;;
+            html_stub)
+                printf "  ${red}Ошибка${reset}: получена HTML-страница вместо dat-файла\n  Невозможно обновить. Оставляем старый файл\n\n"
+                ;;
+            *)
+                printf "  ${red}Ошибка${reset}: не удалось загрузить %s\n" "$display_name"
+                ;;
+        esac
         return 1
-    fi
-
-    # Проверка размера файла
-    local actual_size=$(wc -c < "$temp_file")
-    if [ "$actual_size" -lt "$min_size" ]; then
-        printf "  ${red}Ошибка${reset}: загруженный файл слишком мал (%s bytes) или повреждён\n  Невозможно обновить. Оставляем старый файл\n\n" "$actual_size"
-        rm -f "$temp_file"
-        return 1
-    fi
-
-    # Проверка на HTML
-    if grep -qi "<html" "$temp_file"; then
-        printf "  ${red}Ошибка${reset}: получена HTML-страница вместо dat-файла\n  Невозможно обновить. Оставляем старый файл\n\n"
-        rm -f "$temp_file"
-        return 1
-    fi
-
-    # Безопасная замена
-    if mv "$temp_file" "$geo_dir/$filename.new"; then
-        mv -f "$geo_dir/$filename.new" "$geo_dir/$filename"
     fi
 
     if [ "$update_flag" = "true" ]; then

--- a/scripts/_xkeen/02_install/05_install_geoipset.sh
+++ b/scripts/_xkeen/02_install/05_install_geoipset.sh
@@ -1,50 +1,59 @@
+# Валидаторы для fetch_with_mirrors: проверяют размер + базовый синтаксис
+# содержимого (catch HTML-stub и мусор от proxy-error-page).
+_validate_geoipset_v4() {
+    _validate_default "$1" "$2" || return 1
+    if ! grep -q "^[0-9]" "$1"; then
+        _last_error="content_v4"
+        return 1
+    fi
+    return 0
+}
+
+_validate_geoipset_v6() {
+    _validate_default "$1" "$2" || return 1
+    if ! grep -q ":" "$1"; then
+        _last_error="content_v6"
+        return 1
+    fi
+    return 0
+}
+
 # Функция для установки и обновления GeoIPSET
 install_geoipset_lst() {
     mkdir -p "$ipset_cfg" || { echo "Ошибка: Не удалось создать директорию $ipset_cfg"; exit 1; }
-
-    test_github
 
     url="$1"
     dest_file="$2"
     display_name="$3"
     ip_type="$4"
 
-    temp_file=$(mktemp)
     printf "  Загрузка %s...\n" "$display_name"
 
-    if [ "$use_direct" = "true" ]; then
-        fetch_url="$url"
+    if [ "$ip_type" = "ipv4" ]; then
+        _validator_name="_validate_geoipset_v4"
     else
-        fetch_url="$gh_proxy/$url"
+        _validator_name="_validate_geoipset_v6"
     fi
 
-    eval curl $curl_extra --connect-timeout 10 $curl_timeout -fL -o "$temp_file" "$fetch_url" >/dev/null 2>&1
-    if [ $? -ne 0 ]; then
-        rm -f "$temp_file"
-        printf "  ${red}Ошибка${reset}: не удалось загрузить %s\n\n" "$display_name"
-        return 1
-    fi
-
-    # Проверка на HTML-страницу заглушку
-    if grep -qi "<html" "$temp_file"; then
-        rm -f "$temp_file"
-        printf "  ${red}Ошибка${reset}: получена HTML-страница вместо списка IP\n  Оставляем старый файл\n\n"
-        return 1
-    fi
-
-    # Валидация
-    if [ "$ip_type" = "ipv4" ] && ! grep -q "^[0-9]" "$temp_file"; then
-        rm -f "$temp_file"
-        printf "  ${red}Ошибка${reset}: %s не содержит корректных IPv4-адресов\n  Оставляем старый файл\n\n" "$display_name"
-        return 1
-        elif [ "$ip_type" = "ipv6" ] && ! grep -q ":" "$temp_file"; then
-        rm -f "$temp_file"
-        printf "  ${red}Ошибка${reset}: %s не содержит корректных IPv6-адресов\n  Оставляем старый файл\n\n" "$display_name"
+    if ! fetch_with_mirrors "$url" "$dest_file" 0 "$_validator_name"; then
+        case "$_last_error" in
+            html_stub)
+                printf "  ${red}Ошибка${reset}: получена HTML-страница вместо списка IP\n  Оставляем старый файл\n\n"
+                ;;
+            content_v4)
+                printf "  ${red}Ошибка${reset}: %s не содержит корректных IPv4-адресов\n  Оставляем старый файл\n\n" "$display_name"
+                ;;
+            content_v6)
+                printf "  ${red}Ошибка${reset}: %s не содержит корректных IPv6-адресов\n  Оставляем старый файл\n\n" "$display_name"
+                ;;
+            *)
+                printf "  ${red}Ошибка${reset}: не удалось загрузить %s\n\n" "$display_name"
+                ;;
+        esac
         return 1
     fi
 
     [ "$action" = "init" ] && msg_geoipset="установлен" || msg_geoipset="обновлён"
-    mv -f "$temp_file" "$dest_file"
     printf "  %s ${green}успешно $msg_geoipset${reset}\n\n" "$display_name"
     return 0
 }

--- a/scripts/_xkeen/04_tools/07_tools_downloaders/00_downloaders_import.sh
+++ b/scripts/_xkeen/04_tools/07_tools_downloaders/00_downloaders_import.sh
@@ -1,5 +1,8 @@
 # Импорт модулей загрузки
 
+# fetch_with_mirrors / probe_with_mirrors уже подгружены из xkeen/import.sh
+# (раньше install-модуля, который тоже их вызывает).
+
 # Модули загрузки
 . "$xtools_dir/07_tools_downloaders/01_downloaders_xray.sh"
 . "$xtools_dir/07_tools_downloaders/01_downloaders_mihomo.sh"

--- a/scripts/_xkeen/04_tools/07_tools_downloaders/00_fetch_with_mirrors.sh
+++ b/scripts/_xkeen/04_tools/07_tools_downloaders/00_fetch_with_mirrors.sh
@@ -1,0 +1,200 @@
+# Загрузка с per-call mirror-fallback'ом.
+#
+# Заменяет паттерн "test_github -> один gh_proxy на сессию -> один curl
+# без fallback'а". Старый flow ломается когда выбранный mirror транзиентно
+# падает между test_github и фактической загрузкой: curl получает 5xx или
+# таймаут, caller тихо return 1, geo-файлы устаревают.
+#
+# fetch_with_mirrors пробует префиксы по очереди (gh_proxy_user
+# exclusive, иначе direct + gh_proxy1 + gh_proxy2), кэширует удачный
+# выбор на TTL_SEC, валидирует ответ (HTTP-код + min-size + HTML-stub
+# detect). После неудачного вызова caller может прочитать причину из
+# глобальных переменных _last_error / _last_size (для fetch) и
+# _last_http (для probe), чтобы напечатать осмысленное сообщение.
+
+_mirror_cache="/tmp/.xkeen_mirror_cache"
+_mirror_ttl=60
+_DIRECT_TOKEN="__direct__"
+
+# Чтение закэшированного префикса. stdout = префикс ("" для direct),
+# rc = 0 если кэш свежий, 1 если просрочен/garbage/отсутствует.
+_mirror_cache_read() {
+    [ -r "$_mirror_cache" ] || return 1
+    _cache_ts=""
+    _cache_pfx=""
+    IFS=' ' read -r _cache_ts _cache_pfx < "$_mirror_cache" 2>/dev/null || return 1
+    case "$_cache_ts" in
+        ''|*[!0-9]*) return 1 ;;
+    esac
+    _cache_now=$(date +%s 2>/dev/null) || return 1
+    [ $((_cache_now - _cache_ts)) -lt "$_mirror_ttl" ] || return 1
+    [ "$_cache_pfx" = "$_DIRECT_TOKEN" ] && _cache_pfx=""
+    printf '%s' "$_cache_pfx"
+    return 0
+}
+
+# Сохранение удачного префикса в кэш. $1 = "" для direct, иначе url.
+_mirror_cache_write() {
+    _w_pfx="$1"
+    [ -z "$_w_pfx" ] && _w_pfx="$_DIRECT_TOKEN"
+    printf '%s %s\n' "$(date +%s)" "$_w_pfx" > "$_mirror_cache" 2>/dev/null
+}
+
+# Список префиксов для попыток, по одному на строку, в порядке приоритета.
+# Используется token __direct__ для direct GitHub (пустая строка ломала
+# бы heredoc-итерацию).
+_mirror_order() {
+    if [ -n "$gh_proxy_user" ]; then
+        printf '%s\n' "${gh_proxy_user%/}"
+        return
+    fi
+    _order_cached_set=0
+    if _order_cached=$(_mirror_cache_read); then
+        _order_cached_set=1
+        printf '%s\n' "${_order_cached:-$_DIRECT_TOKEN}"
+    fi
+    # direct и дефолтные mirror'ы, пропуская тот что уже в кэше
+    if [ "$_order_cached_set" = "0" ] || [ -n "$_order_cached" ]; then
+        printf '%s\n' "$_DIRECT_TOKEN"
+    fi
+    if [ -n "$gh_proxy1" ] && [ "$_order_cached" != "${gh_proxy1%/}" ]; then
+        printf '%s\n' "${gh_proxy1%/}"
+    fi
+    if [ -n "$gh_proxy2" ] && [ "$_order_cached" != "${gh_proxy2%/}" ]; then
+        printf '%s\n' "${gh_proxy2%/}"
+    fi
+}
+
+# Дефолтный валидатор для скачанного файла.
+# $1 = path, $2 = min_size (байт, 0 = без проверки размера).
+# Сетит _last_error и _last_size для caller-сообщений.
+#
+# HTML-stub detect: cloudflare challenge, jsdelivr "429: Too Many
+# Requests", proxy-error 404-page под HTTP 200. Маркеры якорные (^...)
+# чтобы не словить false-positive на байтах в gzip/zip/ELF метадате.
+_validate_default() {
+    _v_f="$1"
+    _v_min="${2:-0}"
+    _last_error=""
+    _last_size=0
+    if [ ! -s "$_v_f" ]; then
+        _last_error="curl_failed"
+        return 1
+    fi
+    _last_size=$(wc -c < "$_v_f" 2>/dev/null | tr -d ' ')
+    if [ "$_v_min" -gt 0 ]; then
+        [ -n "$_last_size" ] && [ "$_last_size" -ge "$_v_min" ] || {
+            _last_error="size"
+            return 1
+        }
+    fi
+    if head -c 100 "$_v_f" 2>/dev/null | grep -iqE '^(<!doctype|<html|<head|<body|404|error|not found)'; then
+        _last_error="html_stub"
+        return 1
+    fi
+    return 0
+}
+
+# fetch_with_mirrors <url> <dest> [min_size] [validator]
+#
+# Качает <url> в <dest> через цепочку префиксов, валидирует.
+# Атомарная замена: запись в "${dest}.tmp.$$" + mv.
+#
+# Возврат: 0 на успех, 1 на полный провал (все попытки failed/invalid).
+# При rc != 0: _last_error содержит причину последней неудачи
+# (curl_failed / size / html_stub), _last_size содержит размер файла
+# при size-fail.
+fetch_with_mirrors() {
+    _fwm_url="$1"
+    _fwm_dest="$2"
+    _fwm_min="${3:-0}"
+    _fwm_validator="${4:-_validate_default}"
+    _fwm_tmp="${_fwm_dest}.tmp.$$"
+    _fwm_winner=""
+    _last_error=""
+    _last_size=0
+
+    rm -f "$_fwm_tmp"
+    _fwm_orders=$(_mirror_order)
+    while IFS= read -r _fwm_prefix; do
+        [ "$_fwm_prefix" = "$_DIRECT_TOKEN" ] && _fwm_prefix=""
+        if [ -n "$_fwm_prefix" ]; then
+            _fwm_fetch="$_fwm_prefix/$_fwm_url"
+        else
+            _fwm_fetch="$_fwm_url"
+        fi
+        if eval curl $curl_extra --connect-timeout 10 $curl_timeout \
+               -fL -o "$_fwm_tmp" "$_fwm_fetch" >/dev/null 2>&1; then
+            if "$_fwm_validator" "$_fwm_tmp" "$_fwm_min"; then
+                _fwm_winner="$_fwm_prefix"
+                break
+            fi
+        else
+            _last_error="curl_failed"
+        fi
+        rm -f "$_fwm_tmp"
+    done <<EOF
+$_fwm_orders
+EOF
+
+    if [ -f "$_fwm_tmp" ]; then
+        mv -f "$_fwm_tmp" "$_fwm_dest" || { rm -f "$_fwm_tmp"; return 1; }
+        _mirror_cache_write "$_fwm_winner"
+        _last_error=""
+        return 0
+    fi
+    return 1
+}
+
+# probe_with_mirrors <url>
+#
+# HEAD-probe (с fallback на range-byte для mirror'ов которые не разрешают
+# HEAD и отдают 405). Используется в xray/mihomo downloader'ах для
+# быстрой проверки "существует ли такая версия" перед полной загрузкой.
+#
+# Возврат: 0 на 2xx; 2 если все попытки получили 4xx (definitive miss,
+# например пользователь ввёл неверную версию); 1 на прочие транзиентные
+# ошибки. _last_http содержит HTTP-код последней значимой попытки (для
+# error сообщений caller'а), _last_curl_rc содержит exit-код curl
+# последней попытки (28 = таймаут, остальные см. man curl).
+probe_with_mirrors() {
+    _pwm_url="$1"
+    _pwm_attempts=0
+    _pwm_fail_4xx=0
+    _last_http=""
+    _last_curl_rc=0
+
+    _pwm_orders=$(_mirror_order)
+    while IFS= read -r _pwm_prefix; do
+        [ "$_pwm_prefix" = "$_DIRECT_TOKEN" ] && _pwm_prefix=""
+        if [ -n "$_pwm_prefix" ]; then
+            _pwm_probe="$_pwm_prefix/$_pwm_url"
+        else
+            _pwm_probe="$_pwm_url"
+        fi
+        _pwm_attempts=$((_pwm_attempts + 1))
+        _pwm_code=$(eval curl $curl_extra --connect-timeout 10 $curl_timeout \
+            -I -s -L -w '%{http_code}' -o /dev/null "$_pwm_probe" 2>/dev/null)
+        _last_curl_rc=$?
+        if [ "$_pwm_code" = "405" ]; then
+            _pwm_code=$(eval curl $curl_extra --connect-timeout 10 $curl_timeout \
+                -s -L -r 0-0 -w '%{http_code}' -o /dev/null "$_pwm_probe" 2>/dev/null)
+            _last_curl_rc=$?
+        fi
+        _last_http="$_pwm_code"
+        case "$_pwm_code" in
+            2[0-9][0-9])
+                _mirror_cache_write "$_pwm_prefix"
+                return 0
+                ;;
+            40[0-9])
+                _pwm_fail_4xx=$((_pwm_fail_4xx + 1))
+                ;;
+        esac
+    done <<EOF
+$_pwm_orders
+EOF
+
+    [ "$_pwm_attempts" -gt 0 ] && [ "$_pwm_fail_4xx" = "$_pwm_attempts" ] && return 2
+    return 1
+}

--- a/scripts/_xkeen/04_tools/07_tools_downloaders/01_downloaders_mihomo.sh
+++ b/scripts/_xkeen/04_tools/07_tools_downloaders/01_downloaders_mihomo.sh
@@ -151,8 +151,7 @@ download_mihomo() {
 
         printf "  ${yellow}Выполняется загрузка${reset} парсера конфигурационных файлов Mihomo - Yq\n"
 
-        probe_with_mirrors "$download_yq"
-        if [ "$?" = "0" ]; then
+        if probe_with_mirrors "$download_yq"; then
             if fetch_with_mirrors "$download_yq" "$install_dir/yq" 1024; then
                 chmod +x "$install_dir/yq"
                 yq_available="true"

--- a/scripts/_xkeen/04_tools/07_tools_downloaders/01_downloaders_mihomo.sh
+++ b/scripts/_xkeen/04_tools/07_tools_downloaders/01_downloaders_mihomo.sh
@@ -1,63 +1,5 @@
 # Загрузка Mihomo
 download_mihomo() {
-    test_github
-
-    check_url_availability() {
-        url=$1
-        timeout=$2
-
-        http_status=$(eval curl $curl_extra --connect-timeout "$timeout" $curl_timeout \
-                          -I \
-                          -s \
-                          -L \
-                          -w "%{http_code}" \
-                          -o /dev/null \
-                          "$url" 2>/dev/null)
-        curl_exit_code=$?
-
-        if [ "$curl_exit_code" -eq 0 ] && [ "$http_status" = "405" ]; then
-            http_status=$(eval curl $curl_extra --connect-timeout "$timeout" $curl_timeout \
-                              -s \
-                              -L \
-                              -r 0-0 \
-                              -w "%{http_code}" \
-                              -o /dev/null \
-                              "$url" 2>/dev/null)
-            curl_exit_code=$?
-        fi
-
-        if [ "$curl_exit_code" -eq 28 ]; then
-            printf "  ${red}Таймаут${reset} при проверке\n"
-            return 1
-        elif [ "$curl_exit_code" -ne 0 ]; then
-            printf "  ${red}Ошибка curl ($curl_exit_code)${reset} при проверке\n"
-            return 1
-        fi
-
-        case "$http_status" in
-            2[0-9][0-9])
-                printf "  Файл ${green}доступен${reset}\n"
-                return 0
-                ;;
-            404)
-                printf "  Файл ${red}не найден${reset} (404)\n"
-                return 2
-                ;;
-            403)
-                printf "  ${red}Доступ запрещен${reset} (403)\n"
-                return 2
-                ;;
-            000)
-                printf "  ${red}Нет соединения${reset}\n"
-                return 1
-                ;;
-            *)
-                printf "  ${yellow}Проблема с доступом${reset} (HTTP: $http_status)\n"
-                return 1
-                ;;
-        esac
-    }
-
     USE_JSDELIVR=""
     printf "  ${green}Запрос информации${reset} о релизах ${yellow}Mihomo${reset}\n"
 
@@ -173,44 +115,49 @@ download_mihomo() {
 
         filename=$(basename "$download_url")
         extension="${filename##*.}"
-        yq_dist=$(mktemp)
-        mihomo_dist=$(mktemp)
         mkdir -p "$mtmp_dir"
         yq_available="false"
 
-        if [ "$use_direct" != "true" ]; then
-            download_url="$gh_proxy/$download_url"
-            download_yq="$gh_proxy/$download_yq"
-        fi
-
         printf "  ${yellow}Проверка${reset} доступности версии $version_selected...\n"
 
-        # Проверка доступности версии Mihomo
-        if ! check_url_availability "$download_url" 10; then
-            rm -f "$mihomo_dist"
-            printf "  ${red}Ошибка${reset}: Версия Mihomo $version_selected недоступна\n"
-            continue
-        fi
+        probe_with_mirrors "$download_url"
+        case "$?" in
+            0)
+                printf "  Файл ${green}доступен${reset}\n"
+                ;;
+            2)
+                case "$_last_http" in
+                    403) printf "  ${red}Доступ запрещен${reset} (403)\n" ;;
+                    404) printf "  Файл ${red}не найден${reset} (404)\n" ;;
+                    *)   printf "  ${yellow}Проблема с доступом${reset} (HTTP: %s)\n" "$_last_http" ;;
+                esac
+                printf "  ${red}Ошибка${reset}: Версия Mihomo $version_selected недоступна\n"
+                continue
+                ;;
+            *)
+                if [ "$_last_curl_rc" = "28" ]; then  # curl OPERATION_TIMEDOUT
+                    printf "  ${red}Таймаут${reset} при проверке\n"
+                elif [ "$_last_curl_rc" != "0" ]; then
+                    printf "  ${red}Ошибка curl (%s)${reset} при проверке\n" "$_last_curl_rc"
+                elif [ -n "$_last_http" ] && [ "$_last_http" != "000" ]; then
+                    printf "  ${yellow}Проблема с доступом${reset} (HTTP: %s)\n" "$_last_http"
+                else
+                    printf "  ${red}Нет соединения${reset}\n"
+                fi
+                printf "  ${red}Ошибка${reset}: Версия Mihomo $version_selected недоступна\n"
+                continue
+                ;;
+        esac
 
         printf "  ${yellow}Выполняется загрузка${reset} парсера конфигурационных файлов Mihomo - Yq\n"
 
-        # Загрузка Yq
-        if check_url_availability "$download_yq" 10; then
-            if eval curl $curl_extra --connect-timeout 10 $curl_timeout \
-                   -fL \
-                   -o "$yq_dist" \
-                   "$download_yq" 2>/dev/null; then
-                if [ -s "$yq_dist" ]; then
-                    mv "$yq_dist" "$install_dir/yq"
-                    chmod +x "$install_dir/yq"
-                    yq_available="true"
-                    printf "  Yq ${green}успешно загружен и установлен${reset}\n"
-                else
-                    rm -f "$yq_dist"
-                    printf "  ${red}Ошибка${reset}: Загруженный файл Yq поврежден\n"
-                fi
+        probe_with_mirrors "$download_yq"
+        if [ "$?" = "0" ]; then
+            if fetch_with_mirrors "$download_yq" "$install_dir/yq" 1024; then
+                chmod +x "$install_dir/yq"
+                yq_available="true"
+                printf "  Yq ${green}успешно загружен и установлен${reset}\n"
             else
-                rm -f "$yq_dist"
                 printf "  ${red}Ошибка${reset}: Не удалось загрузить Yq\n"
             fi
         else
@@ -220,42 +167,20 @@ download_mihomo() {
         printf "  ${yellow}Выполняется загрузка${reset} выбранной версии Mihomo\n"
 
         if [ "$yq_available" != "true" ] && [ -x "$install_dir/yq" ]; then
-            rm -f "$yq_dist"
             yq_available="true"
             printf "  ${yellow}Используется${reset} уже установленный Yq\n"
         fi
 
         if [ "$yq_available" != "true" ]; then
-            rm -f "$yq_dist" "$mihomo_dist"
             printf "  ${red}Ошибка${reset}: Для работы Mihomo требуется Yq. Установка прервана\n"
             return 1
         fi
 
-        # Загрузка Mihomo
-        if eval curl $curl_extra --connect-timeout 10 $curl_timeout \
-               -fL \
-               -o "$mihomo_dist" \
-               "$download_url" 2>/dev/null; then
-
-            if [ -s "$mihomo_dist" ]; then
-                if head -c 100 "$mihomo_dist" 2>/dev/null | grep -iq "<!DOCTYPE html\|<html\|Error\|404\|Not Found"; then
-                    rm -f "$mihomo_dist"
-                    printf "  ${red}Ошибка${reset}: Получена HTML страница ошибки вместо файла Mihomo\n"
-                    continue
-                fi
-
-                mv "$mihomo_dist" "$mtmp_dir/mihomo.$extension"
-                printf "  Mihomo ${green}успешно загружен${reset}\n"
-                return 0
-            else
-                rm -f "$mihomo_dist"
-                printf "  ${red}Ошибка${reset}: Загруженный файл Mihomo поврежден\n"
-                continue
-            fi
-        else
-            rm -f "$mihomo_dist"
+        if ! fetch_with_mirrors "$download_url" "$mtmp_dir/mihomo.$extension" 1024; then
             printf "  ${red}Ошибка${reset}: Не удалось загрузить Mihomo $version_selected\n"
             continue
         fi
+        printf "  Mihomo ${green}успешно загружен${reset}\n"
+        return 0
     done
 }

--- a/scripts/_xkeen/04_tools/07_tools_downloaders/01_downloaders_xray.sh
+++ b/scripts/_xkeen/04_tools/07_tools_downloaders/01_downloaders_xray.sh
@@ -1,63 +1,5 @@
 # Загрузка Xray
 download_xray() {
-    test_github
-
-    check_url_availability() {
-        url=$1
-        timeout=$2
-
-        http_status=$(eval curl $curl_extra --connect-timeout "$timeout" $curl_timeout \
-                          -I \
-                          -s \
-                          -L \
-                          -w "%{http_code}" \
-                          -o /dev/null \
-                          "$url" 2>/dev/null)
-        curl_exit_code=$?
-
-        if [ "$curl_exit_code" -eq 0 ] && [ "$http_status" = "405" ]; then
-            http_status=$(eval curl $curl_extra --connect-timeout "$timeout" $curl_timeout \
-                              -s \
-                              -L \
-                              -r 0-0 \
-                              -w "%{http_code}" \
-                              -o /dev/null \
-                              "$url" 2>/dev/null)
-            curl_exit_code=$?
-        fi
-
-        if [ "$curl_exit_code" -eq 28 ]; then
-            printf "  ${red}Таймаут${reset} при проверке\n"
-            return 1
-        elif [ "$curl_exit_code" -ne 0 ]; then
-            printf "  ${red}Ошибка curl ($curl_exit_code)${reset} при проверке\n"
-            return 1
-        fi
-
-        case "$http_status" in
-            2[0-9][0-9])
-                printf "  Файл ${green}доступен${reset}\n"
-                return 0
-                ;;
-            404)
-                printf "  Файл ${red}не найден${reset} (404)\n"
-                return 2
-                ;;
-            403)
-                printf "  ${red}Доступ запрещен${reset} (403)\n"
-                return 2
-                ;;
-            000)
-                printf "  ${red}Нет соединения${reset}\n"
-                return 1
-                ;;
-            *)
-                printf "  ${yellow}Проблема с доступом${reset} (HTTP: $http_status)\n"
-                return 1
-                ;;
-        esac
-    }
-
     USE_JSDELIVR=""
     printf "  ${green}Запрос информации${reset} о релизах ${yellow}Xray${reset}\n"
 
@@ -109,46 +51,47 @@ download_xray() {
 
         filename=$(basename "$download_url")
         extension="${filename##*.}"
-        xray_dist=$(mktemp)
         mkdir -p "$xtmp_dir"
-
-        if [ "$use_direct" != "true" ]; then
-            download_url="$gh_proxy/$download_url"
-        fi
 
         printf "  ${yellow}Проверка${reset} доступности версии %s...\n" "$version_selected"
 
-        if ! check_url_availability "$download_url" 10; then
-            rm -f "$xray_dist"
-            printf "  ${red}Ошибка${reset}: Версия %s недоступна\n" "$version_selected"
-            exit 1
-        fi
+        probe_with_mirrors "$download_url"
+        case "$?" in
+            0)
+                printf "  Файл ${green}доступен${reset}\n"
+                ;;
+            2)
+                case "$_last_http" in
+                    403) printf "  ${red}Доступ запрещен${reset} (403)\n" ;;
+                    404) printf "  Файл ${red}не найден${reset} (404)\n" ;;
+                    *)   printf "  ${yellow}Проблема с доступом${reset} (HTTP: %s)\n" "$_last_http" ;;
+                esac
+                printf "  ${red}Ошибка${reset}: Версия %s недоступна\n" "$version_selected"
+                exit 1
+                ;;
+            *)
+                if [ "$_last_curl_rc" = "28" ]; then  # curl OPERATION_TIMEDOUT
+                    printf "  ${red}Таймаут${reset} при проверке\n"
+                elif [ "$_last_curl_rc" != "0" ]; then
+                    printf "  ${red}Ошибка curl (%s)${reset} при проверке\n" "$_last_curl_rc"
+                elif [ -n "$_last_http" ] && [ "$_last_http" != "000" ]; then
+                    printf "  ${yellow}Проблема с доступом${reset} (HTTP: %s)\n" "$_last_http"
+                else
+                    printf "  ${red}Нет соединения${reset}\n"
+                fi
+                printf "  ${red}Ошибка${reset}: Версия %s недоступна\n" "$version_selected"
+                exit 1
+                ;;
+        esac
 
         printf "  ${yellow}Выполняется загрузка${reset} последней версии Xray\n"
 
-        if eval curl $curl_extra --connect-timeout 10 $curl_timeout \
-               -fL \
-               -o "$xray_dist" \
-               "$download_url" 2>/dev/null; then
-            if [ -s "$xray_dist" ]; then
-                if head -c 100 "$xray_dist" 2>/dev/null | grep -iq "<!DOCTYPE html\|<html\|Error\|404\|Not Found"; then
-                    rm -f "$xray_dist"
-                    printf "  ${red}Ошибка${reset}: Получена HTML страница ошибки вместо файла\n"
-                    exit 1
-                fi
-                mv "$xray_dist" "$xtmp_dir/xray.$extension"
-                printf "  Xray ${green}успешно загружен${reset}\n"
-                return 0
-            else
-                rm -f "$xray_dist"
-                printf "  ${red}Ошибка${reset}: Загруженный файл Xray поврежден\n"
-                exit 1
-            fi
-        else
-            rm -f "$xray_dist"
+        if ! fetch_with_mirrors "$download_url" "$xtmp_dir/xray.$extension" 1024; then
             printf "  ${red}Ошибка${reset}: Не удалось загрузить Xray %s\n" "$version_selected"
             exit 1
         fi
+        printf "  Xray ${green}успешно загружен${reset}\n"
+        return 0
     fi
 
     while true; do
@@ -219,49 +162,46 @@ download_xray() {
 
         filename=$(basename "$download_url")
         extension="${filename##*.}"
-        xray_dist=$(mktemp)
         mkdir -p "$xtmp_dir"
-
-        if [ "$use_direct" != "true" ]; then
-            download_url="$gh_proxy/$download_url"
-        fi
 
         printf "  ${yellow}Проверка${reset} доступности версии $version_selected...\n"
 
-        # Проверка доступности версии
-        if ! check_url_availability "$download_url" 10; then
-            rm -f "$xray_dist"
-            printf "  ${red}Ошибка${reset}: Версия $version_selected недоступна\n"
-            continue
-        fi
+        probe_with_mirrors "$download_url"
+        case "$?" in
+            0)
+                printf "  Файл ${green}доступен${reset}\n"
+                ;;
+            2)
+                case "$_last_http" in
+                    403) printf "  ${red}Доступ запрещен${reset} (403)\n" ;;
+                    404) printf "  Файл ${red}не найден${reset} (404)\n" ;;
+                    *)   printf "  ${yellow}Проблема с доступом${reset} (HTTP: %s)\n" "$_last_http" ;;
+                esac
+                printf "  ${red}Ошибка${reset}: Версия $version_selected недоступна\n"
+                continue
+                ;;
+            *)
+                if [ "$_last_curl_rc" = "28" ]; then  # curl OPERATION_TIMEDOUT
+                    printf "  ${red}Таймаут${reset} при проверке\n"
+                elif [ "$_last_curl_rc" != "0" ]; then
+                    printf "  ${red}Ошибка curl (%s)${reset} при проверке\n" "$_last_curl_rc"
+                elif [ -n "$_last_http" ] && [ "$_last_http" != "000" ]; then
+                    printf "  ${yellow}Проблема с доступом${reset} (HTTP: %s)\n" "$_last_http"
+                else
+                    printf "  ${red}Нет соединения${reset}\n"
+                fi
+                printf "  ${red}Ошибка${reset}: Версия $version_selected недоступна\n"
+                continue
+                ;;
+        esac
 
         printf "  ${yellow}Выполняется загрузка${reset} выбранной версии Xray\n"
 
-        # Загрузка Xray
-        if eval curl $curl_extra --connect-timeout 10 $curl_timeout \
-               -fL \
-               -o "$xray_dist" \
-               "$download_url" 2>/dev/null; then
-
-            if [ -s "$xray_dist" ]; then
-                if head -c 100 "$xray_dist" 2>/dev/null | grep -iq "<!DOCTYPE html\|<html\|Error\|404\|Not Found"; then
-                    rm -f "$xray_dist"
-                    printf "  ${red}Ошибка${reset}: Получена HTML страница ошибки вместо файла\n"
-                    continue
-                fi
-
-                mv "$xray_dist" "$xtmp_dir/xray.$extension"
-                printf "  Xray ${green}успешно загружен${reset}\n"
-                return 0
-            else
-                rm -f "$xray_dist"
-                printf "  ${red}Ошибка${reset}: Загруженный файл Xray поврежден\n"
-                continue
-            fi
-        else
-            rm -f "$xray_dist"
+        if ! fetch_with_mirrors "$download_url" "$xtmp_dir/xray.$extension" 1024; then
             printf "  ${red}Ошибка${reset}: Не удалось загрузить Xray $version_selected\n"
             continue
         fi
+        printf "  Xray ${green}успешно загружен${reset}\n"
+        return 0
     done
 }

--- a/scripts/_xkeen/04_tools/07_tools_downloaders/02_donwloaders_xkeen.sh
+++ b/scripts/_xkeen/04_tools/07_tools_downloaders/02_donwloaders_xkeen.sh
@@ -1,29 +1,15 @@
 # Загрузка XKeen
 download_xkeen() {
-    test_github
-    xkeen_dist=$(mktemp)
     mkdir -p "$ktmp_dir"
     printf "  ${yellow}Выполняется загрузка${reset} XKeen\n"
 
-    if [ "$use_direct" != "true" ]; then
-        xkeen_tar_url="$gh_proxy/$xkeen_tar_url"
-    fi
-
-    if eval curl $curl_extra --connect-timeout 10 $curl_timeout -fL -o "$xkeen_dist" "$xkeen_tar_url" 2>/dev/null; then
-        if [ -s "$xkeen_dist" ]; then
-            mv "$xkeen_dist" "$ktmp_dir/xkeen.tar.gz"
-            printf "  XKeen ${green}успешно загружен${reset}\n"
-            return 0
-        else
-            rm -f "$xkeen_dist"
-            printf "  ${red}Ошибка${reset}: Загруженный файл XKeen поврежден\n"
-            exit 1
-        fi
-    else
-        rm -f "$xkeen_dist"
+    if ! fetch_with_mirrors "$xkeen_tar_url" "$ktmp_dir/xkeen.tar.gz" 1024; then
         printf "  ${red}Ошибка${reset}: Не удалось загрузить XKeen\n"
         exit 1
     fi
+
+    printf "  XKeen ${green}успешно загружен${reset}\n"
+    return 0
 }
 
 download_xkeen_dev() {

--- a/scripts/_xkeen/05_tests/01_tests_connected.sh
+++ b/scripts/_xkeen/05_tests/01_tests_connected.sh
@@ -71,79 +71,36 @@ get_user_proxy() {
     [ "$gh_proxy_user" = "null" ] && gh_proxy_user=""
 }
 
-# Функция проверки доступности GitHub
+# Функция проверки доступности GitHub.
+# Тонкая обёртка над probe_with_mirrors: идентичная философия (пара URL
+# через одну цепочку префиксов, exclusive gh_proxy_user, exit 1 на
+# полную недоступность), но один engine fallback в helper'е вместо
+# дублирования логики direct/proxy1/proxy2 здесь.
 test_github() {
-    if [ "$use_direct" = "true" ] || [ -n "$gh_proxy" ]; then
-        return 0
-    fi
+    [ -n "$_gh_probed" ] && return 0
 
     get_user_proxy
 
-    _tmp1="/tmp/.xkeen_test_1.$$"
-    _tmp2="/tmp/.xkeen_test_2.$$"
-
-    _cleanup() {
-        rm -f "$_tmp1" "$_tmp2" 2>/dev/null
-    }
-
-    _check_pair_download() {
-        _prefix="$1"
-
-        # Запускаем оба теста в фоновом режиме
-        download_with_check "${_prefix}${xkeen_tar_url}" "$_tmp1" & pid1=$!
-        download_with_check "${_prefix}${xkeen_dev_url}" "$_tmp2" & pid2=$!
-
-        wait $pid1; res1=$?
-        wait $pid2; res2=$?
-
-        # Возвращаем 0 (успех) только если оба теста успешны
-        [ $res1 -eq 0 ] && [ $res2 -eq 0 ]
-    }
-
-    if [ -n "$gh_proxy_user" ]; then
-        printf "  ${yellow}Используется пользовательский прокси:${reset} $gh_proxy_user\n"
-
-        _proxy_prefix="${gh_proxy_user%/}/"
-
-        if _check_pair_download "$_proxy_prefix"; then
-            gh_proxy="$gh_proxy_user"
-            use_direct="false"
-            printf "  GitHub ${green}доступен через ваш прокси${reset}. Продолжаем...\n"
-            return 0
-        else
-            printf "  ${red}Ошибка${reset}: Указанный вами прокси $gh_proxy_user недоступен\n"
-            _cleanup
-            exit 1
-        fi
-    fi
-
-    use_direct="false"
-    gh_proxy=""
-
     printf "  ${yellow}Проверка доступности${reset} GitHub. Подождите, пожалуйста...\n"
 
-    # Прямая загрузка
-    if _check_pair_download ""; then
-        use_direct="true"
-        printf "  GitHub ${green}доступен${reset}. Продолжаем...\n"
+    # Pair probe: github.com (releases) + raw.githubusercontent.com
+    # (для dev-обновления). Разные CDN, разный uptime, проверяем оба.
+    if probe_with_mirrors "$xkeen_tar_url" && probe_with_mirrors "$xkeen_dev_url"; then
+        _gh_probed=1
+        if [ -n "$gh_proxy_user" ]; then
+            printf "  GitHub ${green}доступен через ваш прокси${reset}: ${yellow}$gh_proxy_user${reset}. Продолжаем...\n"
+        elif [ -r /tmp/.xkeen_mirror_cache ] && grep -q "__direct__" /tmp/.xkeen_mirror_cache 2>/dev/null; then
+            printf "  GitHub ${green}доступен${reset}. Продолжаем...\n"
+        else
+            printf "  GitHub ${green}доступен через прокси${reset}. Продолжаем...\n"
+        fi
         return 0
     fi
 
-    # Загрузка через Proxy 1
-    if [ -n "$gh_proxy1" ] && _check_pair_download "${gh_proxy1}/"; then
-        gh_proxy="$gh_proxy1"
-        printf "  GitHub ${green}доступен через прокси${reset}. Продолжаем...\n"
-        return 0
+    if [ -n "$gh_proxy_user" ]; then
+        printf "  ${red}Ошибка${reset}: Указанный вами прокси $gh_proxy_user недоступен\n"
+    else
+        printf "  ${red}Ошибка${reset}: GitHub недоступен\n"
     fi
-
-    # Загрузка через Proxy 2
-    if [ -n "$gh_proxy2" ] && _check_pair_download "${gh_proxy2}/"; then
-        gh_proxy="$gh_proxy2"
-        printf "  GitHub ${green}доступен через прокси${reset}. Продолжаем...\n"
-        return 0
-    fi
-
-    _cleanup
-    printf "  ${red}Ошибка${reset}: GitHub недоступен\n"
     exit 1
 }

--- a/scripts/_xkeen/05_tests/01_tests_connected.sh
+++ b/scripts/_xkeen/05_tests/01_tests_connected.sh
@@ -58,6 +58,7 @@ test_entware() {
 
 # Функция определения пользовательского прокси для GitHub
 get_user_proxy() {
+    gh_proxy_user=""
     [ ! -f "$xkeen_config" ] && return 1
 
     if command -v jq >/dev/null 2>&1; then

--- a/scripts/_xkeen/import.sh
+++ b/scripts/_xkeen/import.sh
@@ -11,6 +11,11 @@ main_dir="$script_dir/.xkeen"
 # Модуль информации
 . "$xinfo_dir/00_info_import.sh"
 
+# Mirror-fallback helper. Загружается до install-модуля, потому что
+# install-модуль (04_install_geofile, 05_install_geoipset) вызывает
+# fetch_with_mirrors напрямую.
+. "$xtools_dir/07_tools_downloaders/00_fetch_with_mirrors.sh"
+
 # Модуль установки
 . "$xinstall_dir/00_install_import.sh"
 


### PR DESCRIPTION
В связи с проблемами доступа к гитхабу из РФ решил поковырять xkeen в эту сторону. Посмотрел на текущий fallback: `test_github` в начале команды один раз выбирает откуда качать (direct, `gh_proxy1` или `gh_proxy2`) и фиксирует это на всю сессию. Если выбранный вариант отвалится между проверкой и реальным скачиванием, дальше всё тихо не качается, файлы остаются прошлой недели, никакого сигнала об ошибке.

Предлагаю решать на каждый файл отдельно, а не один раз. Тем более в `install.sh` такой fallback (direct -> gh-proxy.com -> ghfast.top) уже есть, просто до остальных downloader'ов не дотянут.

Сделал общий `fetch_with_mirrors` в `04_tools/07_tools_downloaders/00_fetch_with_mirrors.sh`, через него теперь идут `process_geo_file`, `install_geoipset_lst` и `download_xray`/`download_mihomo`/`download_xkeen`. На каждый вызов пробует cached -> direct -> `gh_proxy1` -> `gh_proxy2`, кэш в `/tmp/.xkeen_mirror_cache` с TTL 60 секунд, чтобы серия из нескольких файлов прошла через один канал, но после простоя пробовался свежий выбор. Пишет во временный файл, после успешной проверки переименовывает в финальный. Проверка по умолчанию смотрит на размер и на первые 100 байт: если там html-страница или текст ошибки вроде `404 Not Found` или `Error: 502`, файл считается невалидным.

Для xray и mihomo в комплекте идёт `probe_with_mirrors`. Это `HEAD`-запрос с фолбэком на короткий `GET` с заголовком `Range`, для прокси, которые отвечают `405` на `HEAD`. Возвращает `0` / `1` / `2` чтобы downloader отличал "версия не существует" от "надо ретрайнуть". Заодно вырезал локальную `check_url_availability` на 60 строк, она была скопирована в двух местах байт-в-байт.

`test_github` тоже свёл к тонкой обёртке вокруг `probe_with_mirrors` (75 -> 32 строки), чтобы fallback chain больше не дублировался.

Что поменялось:
- mirror пробуется на каждый файл, а не один раз на сессию
- ошибки скачивания различаются по причине (нет связи, слишком маленький, html-страница, `4xx`, таймаут, curl rc), downloader'ы выводят понятные сообщения

Что осталось как было:
- `gh_proxy_user` в `xkeen.json` exclusive: если задан, используется только он, без скрытого fallback на default
- проверка двух URL в `test_github`
- сообщения "GitHub доступен / через прокси / через ваш прокси", `exit 1` при полной недоступности
- логика выбора версии xray/mihomo через GitHub API с jsDelivr fallback не тронута
- тексты ошибок в downloader'ах те же: "загруженный файл слишком мал", "получена HTML-страница", "Файл не найден (404)", "Доступ запрещен (403)", "Таймаут при проверке", "Ошибка curl (N)"

Проверил на Hopper SE (aarch64), xray в Hybrid:
- `xkeen -ug` качает все геофайлы, кэш direct
- `iptables -A OUTPUT -d 140.82.0.0/16 -j DROP` + `xkeen -ug`: переключение на gh-proxy.com за 12 секунд (до фикса падало с "GitHub недоступен")
- дополнительно DROP gh-proxy.com: идёт через ghfast.top
- `gh_proxy` в `xkeen.json` указан на нерабочий: за секунду `exit 1` "Указанный вами прокси недоступен", без скрытого fallback на default
- `xkeen -uxr` с несуществующей версией: probe вернул код `2`, "Файл не найден (404)", loop попросил ввести версию заново

Такое решение на ваш суд. Если что-то не нравится или есть взгляд под другим углом, готов поменять или доделать.
