### PR TITLE
style: дочистка $? в case-блоках xray/mihomo

### DIFF
--- a/scripts/_xkeen/04_tools/07_tools_downloaders/01_downloaders_mihomo.sh
+++ b/scripts/_xkeen/04_tools/07_tools_downloaders/01_downloaders_mihomo.sh
@@ -121,7 +121,8 @@ download_mihomo() {
         printf "  ${yellow}Проверка${reset} доступности версии $version_selected...\n"
 
         probe_with_mirrors "$download_url"
-        case "$?" in
+        _rc=$?
+        case "$_rc" in
             0)
                 printf "  Файл ${green}доступен${reset}\n"
                 ;;

--- a/scripts/_xkeen/04_tools/07_tools_downloaders/01_downloaders_xray.sh
+++ b/scripts/_xkeen/04_tools/07_tools_downloaders/01_downloaders_xray.sh
@@ -56,7 +56,8 @@ download_xray() {
         printf "  ${yellow}Проверка${reset} доступности версии %s...\n" "$version_selected"
 
         probe_with_mirrors "$download_url"
-        case "$?" in
+        _rc=$?
+        case "$_rc" in
             0)
                 printf "  Файл ${green}доступен${reset}\n"
                 ;;
@@ -167,7 +168,8 @@ download_xray() {
         printf "  ${yellow}Проверка${reset} доступности версии $version_selected...\n"
 
         probe_with_mirrors "$download_url"
-        case "$?" in
+        _rc=$?
+        case "$_rc" in
             0)
                 printf "  Файл ${green}доступен${reset}\n"
                 ;;


### PR DESCRIPTION
Дополнение к #51, не успел дослать вместе. Тот же `SC2181`, что был зачищен там в Yq probe, но в трёх case-блоках после `probe_with_mirrors` (xray auto, xray manual, mihomo). Заменил на промежуточный `$_rc`.
