### PR TITLE
Ci/p3 workflow bump

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Upload artifact

--- a/.github/workflows/package-folder.yaml
+++ b/.github/workflows/package-folder.yaml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/wiki-sync.yaml
+++ b/.github/workflows/wiki-sync.yaml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,14 @@ graphify-out
 done
 src/graphify
 src/output
+
+# Артефакты сборки (CI-генерируемые)
+*.tar.gz
+*.tar
+
+# Явное исключение для Beta-канала
+!test/xkeen.tar.gz
+!test/xkeen.tar
+
+# Локальные release-notes (не для коммита в PR)
+docs/release-notes/


### PR DESCRIPTION
## Summary
Обновление CI-зависимостей и .gitignore для защиты от случайных бинарей.

## Изменения
1. **actions/checkout v5/v4 → v6** в трёх workflow:
   - `.github/workflows/release.yaml`
   - `.github/workflows/wiki-sync.yaml`
   - `.github/workflows/package-folder.yaml`
   
   v6 — последний major release на 2026-05-16 (node 24, исправления tag fetch).

2. **.gitignore**:
   - `*.tar.gz` и `*.tar` — защита от случайных бинарей.
   - `!test/xkeen.tar.gz` (и `.tar`) — явное разрешение для Beta-канала (артефакт CI).
   - `docs/release-notes/` — локальные заметки релизов.