### PR TITLE
fix(install): валидация бинаря и явные ошибки установки ядер

### DIFF
--- a/scripts/_xkeen/01_info/04_info_mihomo.sh
+++ b/scripts/_xkeen/01_info/04_info_mihomo.sh
@@ -1,7 +1,7 @@
 # Функция для проверки установки Mihomo
 
 info_mihomo() {
-    if [ -f "$install_dir/mihomo" ] && [ -f "$install_dir/yq" ]; then
+    if [ -x "$install_dir/mihomo" ] && [ -x "$install_dir/yq" ]; then
         mihomo_installed="installed"
     else
         mihomo_installed="not_installed"

--- a/scripts/_xkeen/01_info/04_info_xray.sh
+++ b/scripts/_xkeen/01_info/04_info_xray.sh
@@ -1,7 +1,7 @@
 # Функция для проверки установки Xray
 
 info_xray() {
-    if [ -f "$install_dir/xray" ]; then
+    if [ -x "$install_dir/xray" ]; then
         xray_installed="installed"
     else
         xray_installed="not_installed"

--- a/scripts/_xkeen/02_install/02_install_mihomo.sh
+++ b/scripts/_xkeen/02_install/02_install_mihomo.sh
@@ -79,6 +79,8 @@ install_mihomo() {
     if ! mv "${mtmp_dir}/mihomo" "$install_dir/" 2>"${mv_err}"; then
         _err="$(cat "${mv_err}" 2>/dev/null)"
         rm -f "${mv_err}" "${mtmp_dir}/mihomo"
+        # Зачищаем возможный недописанный мусор в целевой директории
+        rm -f "$install_dir/mihomo"
         echo -e "  ${red}Ошибка${reset}: Не удалось переместить Mihomo в ${install_dir}"
         [ -n "${_err}" ] && echo -e "  Подробности: ${_err}"
         case "${_err}" in

--- a/scripts/_xkeen/02_install/02_install_mihomo.sh
+++ b/scripts/_xkeen/02_install/02_install_mihomo.sh
@@ -16,18 +16,56 @@ install_mihomo() {
     fi
 
     _mihomo_tmp="${mtmp_dir}/mihomo.tmp.$$"
-    if gzip -cd "${mihomo_archive}" > "${_mihomo_tmp}" 2>/dev/null && [ -s "${_mihomo_tmp}" ]; then
-        mv "${_mihomo_tmp}" "${mtmp_dir}/mihomo"
-        rm -f "${mihomo_archive}"
+    gzip_err="${mtmp_dir}/gzip.err.$$"
+    if gzip -cd "${mihomo_archive}" > "${_mihomo_tmp}" 2>"${gzip_err}" && [ -s "${_mihomo_tmp}" ]; then
+        rm -f "${gzip_err}"
     else
-        rm -f "${_mihomo_tmp}" "${mihomo_archive}"
-        echo -e "  ${red}Ошибка${reset}: Не удалось распаковать архив или файл отсутствует"
+        _err="$(cat "${gzip_err}" 2>/dev/null)"
+        rm -f "${gzip_err}" "${_mihomo_tmp}" "${mihomo_archive}"
+        echo -e "  ${red}Ошибка${reset}: Не удалось распаковать архив Mihomo"
+        [ -n "${_err}" ] && echo -e "  Подробности: ${_err}"
+        case "${_err}" in
+            *"No space left"*|*"ENOSPC"*|*"места"*)
+                echo -e "  ${yellow}Недостаточно свободного места${reset} на разделе с ${install_dir}"
+                ;;
+        esac
         if [ -f "$install_dir/mihomo_bak" ]; then
             mv "$install_dir/mihomo_bak" "$install_dir/mihomo"
             echo -e "  ${yellow}Восстановлен${reset} предыдущий бинарник Mihomo"
         fi
         return 1
     fi
+
+    # Валидация ELF-сигнатуры распакованного файла (защита от обрезанного gzip-вывода)
+    elf_magic="$(dd if="${_mihomo_tmp}" bs=4 count=1 2>/dev/null | od -An -tx1 | tr -d ' \n\t')"
+    if [ "${elf_magic}" != "7f454c46" ]; then
+        rm -f "${_mihomo_tmp}" "${mihomo_archive}"
+        echo -e "  ${red}Ошибка${reset}: Распакованный файл Mihomo не является ELF-бинарём (повреждён или не докачан)"
+        if [ -f "$install_dir/mihomo_bak" ]; then
+            mv "$install_dir/mihomo_bak" "$install_dir/mihomo"
+            echo -e "  ${yellow}Восстановлен${reset} предыдущий бинарник Mihomo"
+        fi
+        return 1
+    fi
+
+    # Sanity-size: Mihomo binary весит 10+ MB, меньше 1 MB означает обрезанный файл
+    sz="$(wc -c < "${_mihomo_tmp}" 2>/dev/null)"
+    case "$sz" in
+        ''|*[!0-9]*) sz=0 ;;
+    esac
+    if [ "$sz" -lt 1048576 ]; then
+        rm -f "${_mihomo_tmp}" "${mihomo_archive}"
+        echo -e "  ${red}Ошибка${reset}: Распакованный файл Mihomo подозрительно мал (${sz} B) — вероятно, обрезан"
+        if [ -f "$install_dir/mihomo_bak" ]; then
+            mv "$install_dir/mihomo_bak" "$install_dir/mihomo"
+            echo -e "  ${yellow}Восстановлен${reset} предыдущий бинарник Mihomo"
+        fi
+        return 1
+    fi
+
+    mv "${_mihomo_tmp}" "${mtmp_dir}/mihomo"
+    rm -f "${mihomo_archive}"
+
     if [ ! -f "${mtmp_dir}/mihomo" ]; then
         echo -e "  ${red}Ошибка${reset}: Не удалось распаковать архив или файл отсутствует"
         if [ -f "$install_dir/mihomo_bak" ]; then
@@ -37,13 +75,39 @@ install_mihomo() {
         return 1
     fi
 
-    if ! mv "${mtmp_dir}/mihomo" "$install_dir/"; then
-        echo -e "  ${red}Ошибка${reset}: Не удалось установить Mihomo"
-        [ -f "$install_dir/mihomo_bak" ] && mv "$install_dir/mihomo_bak" "$install_dir/mihomo"
+    mv_err="${mtmp_dir}/mv.err.$$"
+    if ! mv "${mtmp_dir}/mihomo" "$install_dir/" 2>"${mv_err}"; then
+        _err="$(cat "${mv_err}" 2>/dev/null)"
+        rm -f "${mv_err}" "${mtmp_dir}/mihomo"
+        echo -e "  ${red}Ошибка${reset}: Не удалось переместить Mihomo в ${install_dir}"
+        [ -n "${_err}" ] && echo -e "  Подробности: ${_err}"
+        case "${_err}" in
+            *"No space left"*|*"ENOSPC"*|*"места"*)
+                echo -e "  ${yellow}Недостаточно свободного места${reset} на разделе с ${install_dir}"
+                ;;
+        esac
+        if [ -f "$install_dir/mihomo_bak" ]; then
+            mv "$install_dir/mihomo_bak" "$install_dir/mihomo"
+            echo -e "  ${yellow}Восстановлен${reset} предыдущий бинарник Mihomo"
+        fi
+        return 1
+    fi
+    rm -f "${mv_err}"
+
+    chmod +x "$install_dir/mihomo"
+
+    # Финальная проверка: бинарь существует, исполняем, запускается
+    if [ ! -x "$install_dir/mihomo" ] || ! "$install_dir/mihomo" -v >/dev/null 2>&1; then
+        echo -e "  ${red}Ошибка${reset}: Установленный Mihomo не запускается (повреждён или несовместим с архитектурой)"
+        rm -f "$install_dir/mihomo"
+        if [ -f "$install_dir/mihomo_bak" ]; then
+            mv "$install_dir/mihomo_bak" "$install_dir/mihomo"
+            echo -e "  ${yellow}Восстановлен${reset} предыдущий бинарник Mihomo"
+        fi
         return 1
     fi
 
-    chmod +x "$install_dir/mihomo"
+    rm -f "$install_dir/mihomo_bak"
     echo -e "  Mihomo ${green}успешно установлен${reset}"
 
     return 0

--- a/scripts/_xkeen/02_install/02_install_mihomo.sh
+++ b/scripts/_xkeen/02_install/02_install_mihomo.sh
@@ -37,10 +37,10 @@ install_mihomo() {
     fi
 
     # Валидация ELF-сигнатуры распакованного файла (защита от обрезанного gzip-вывода)
-    elf_magic="$(dd if="${_mihomo_tmp}" bs=4 count=1 2>/dev/null | od -An -tx1 | tr -d ' \n\t')"
+    elf_magic="$(hexdump -n 4 -e '4/1 "%02x"' "${_mihomo_tmp}" 2>/dev/null)"
     if [ "${elf_magic}" != "7f454c46" ]; then
         rm -f "${_mihomo_tmp}" "${mihomo_archive}"
-        echo -e "  ${red}Ошибка${reset}: Распакованный файл Mihomo не является ELF-бинарём (повреждён или не докачан)"
+        echo -e "  ${red}Ошибка${reset}: Распакованный файл Mihomo не является ELF-бинарником (повреждён или не докачан)"
         if [ -f "$install_dir/mihomo_bak" ]; then
             mv "$install_dir/mihomo_bak" "$install_dir/mihomo"
             echo -e "  ${yellow}Восстановлен${reset} предыдущий бинарник Mihomo"
@@ -96,7 +96,7 @@ install_mihomo() {
 
     chmod +x "$install_dir/mihomo"
 
-    # Финальная проверка: бинарь существует, исполняем, запускается
+    # Финальная проверка: бинарник существует, исполняем, запускается
     if [ ! -x "$install_dir/mihomo" ] || ! "$install_dir/mihomo" -v >/dev/null 2>&1; then
         echo -e "  ${red}Ошибка${reset}: Установленный Mihomo не запускается (повреждён или несовместим с архитектурой)"
         rm -f "$install_dir/mihomo"

--- a/scripts/_xkeen/02_install/02_install_xray.sh
+++ b/scripts/_xkeen/02_install/02_install_xray.sh
@@ -61,9 +61,9 @@ install_xray() {
     fi
 
     # Валидация ELF-сигнатуры (защита от обрезанного unzip-вывода)
-    elf_magic="$(dd if="$bin_source" bs=4 count=1 2>/dev/null | od -An -tx1 | tr -d ' \n\t')"
+    elf_magic="$(hexdump -n 4 -e '4/1 "%02x"' "$bin_source" 2>/dev/null)"
     if [ "${elf_magic}" != "7f454c46" ]; then
-        echo -e "  ${red}Ошибка${reset}: Распакованный файл Xray не является ELF-бинарём (повреждён или не докачан)"
+        echo -e "  ${red}Ошибка${reset}: Распакованный файл Xray не является ELF-бинарником (повреждён или не докачан)"
         if [ -f "$install_dir/xray_bak" ]; then
             mv "$install_dir/xray_bak" "$install_dir/xray"
             echo -e "  ${yellow}Восстановлен${reset} предыдущий бинарник Xray"
@@ -112,7 +112,7 @@ install_xray() {
 
     chmod +x "$install_dir/xray"
 
-    # Финальная проверка: бинарь существует, исполняем, запускается
+    # Финальная проверка: бинарник существует, исполняем, запускается
     if [ ! -x "$install_dir/xray" ] || ! "$install_dir/xray" version >/dev/null 2>&1; then
         echo -e "  ${red}Ошибка${reset}: Установленный Xray не запускается (повреждён или несовместим с архитектурой)"
         rm -f "$install_dir/xray"

--- a/scripts/_xkeen/02_install/02_install_xray.sh
+++ b/scripts/_xkeen/02_install/02_install_xray.sh
@@ -26,6 +26,8 @@ install_xray() {
         rm -f "${unzip_err}"
         rm -rf "${xtmp_dir}/xray"
         rm -f "${xray_archive}"
+        # Гарантированно убираем возможный маркер незавершенного файла перед восстановлением бэкапа
+        rm -f "${install_dir}/xray"
         echo -e "  ${red}Ошибка${reset}: Не удалось распаковать архив Xray"
         [ -n "${_err}" ] && echo -e "  Подробности: ${_err}"
         case "${_err}" in
@@ -51,6 +53,7 @@ install_xray() {
 
     if [ ! -f "$bin_source" ]; then
         echo -e "  ${red}Ошибка${reset}: Бинарный файл Xray не найден в архиве"
+        rm -f "${install_dir}/xray"
         if [ -f "$install_dir/xray_bak" ]; then
             mv "$install_dir/xray_bak" "$install_dir/xray"
             echo -e "  ${yellow}Восстановлен${reset} предыдущий бинарник Xray"
@@ -64,6 +67,7 @@ install_xray() {
     elf_magic="$(hexdump -n 4 -e '4/1 "%02x"' "$bin_source" 2>/dev/null)"
     if [ "${elf_magic}" != "7f454c46" ]; then
         echo -e "  ${red}Ошибка${reset}: Распакованный файл Xray не является ELF-бинарником (повреждён или не докачан)"
+        rm -f "${install_dir}/xray"
         if [ -f "$install_dir/xray_bak" ]; then
             mv "$install_dir/xray_bak" "$install_dir/xray"
             echo -e "  ${yellow}Восстановлен${reset} предыдущий бинарник Xray"
@@ -80,6 +84,7 @@ install_xray() {
     esac
     if [ "$sz" -lt 1048576 ]; then
         echo -e "  ${red}Ошибка${reset}: Распакованный файл Xray подозрительно мал (${sz} B) — вероятно, обрезан"
+        rm -f "${install_dir}/xray"
         if [ -f "$install_dir/xray_bak" ]; then
             mv "$install_dir/xray_bak" "$install_dir/xray"
             echo -e "  ${yellow}Восстановлен${reset} предыдущий бинарник Xray"
@@ -93,6 +98,7 @@ install_xray() {
     if ! mv "$bin_source" "$install_dir/xray" 2>"${mv_err}"; then
         _err="$(cat "${mv_err}" 2>/dev/null)"
         rm -f "${mv_err}"
+        rm -f "${install_dir}/xray"
         echo -e "  ${red}Ошибка${reset}: Не удалось переместить Xray в ${install_dir}"
         [ -n "${_err}" ] && echo -e "  Подробности: ${_err}"
         case "${_err}" in

--- a/scripts/_xkeen/02_install/02_install_xray.sh
+++ b/scripts/_xkeen/02_install/02_install_xray.sh
@@ -20,11 +20,26 @@ install_xray() {
         rm -rf "${xtmp_dir}/xray"
     fi
 
-    if ! unzip -q "${xray_archive}" -d "${xtmp_dir}/xray"; then
-        echo -e "  ${red}Ошибка${reset}: Не удалось распаковать архив"
-        [ -f "$install_dir/xray_bak" ] && mv "$install_dir/xray_bak" "$install_dir/xray"
+    unzip_err="${xtmp_dir}/unzip.err.$$"
+    if ! unzip -q "${xray_archive}" -d "${xtmp_dir}/xray" 2>"${unzip_err}"; then
+        _err="$(cat "${unzip_err}" 2>/dev/null)"
+        rm -f "${unzip_err}"
+        rm -rf "${xtmp_dir}/xray"
+        rm -f "${xray_archive}"
+        echo -e "  ${red}Ошибка${reset}: Не удалось распаковать архив Xray"
+        [ -n "${_err}" ] && echo -e "  Подробности: ${_err}"
+        case "${_err}" in
+            *"No space left"*|*"ENOSPC"*|*"места"*)
+                echo -e "  ${yellow}Недостаточно свободного места${reset} на разделе с ${install_dir}"
+                ;;
+        esac
+        if [ -f "$install_dir/xray_bak" ]; then
+            mv "$install_dir/xray_bak" "$install_dir/xray"
+            echo -e "  ${yellow}Восстановлен${reset} предыдущий бинарник Xray"
+        fi
         return 1
     fi
+    rm -f "${unzip_err}"
 
     bin_source="${xtmp_dir}/xray/xray"
 
@@ -45,8 +60,72 @@ install_xray() {
         return 1
     fi
 
-    mv "$bin_source" "$install_dir/xray"
+    # Валидация ELF-сигнатуры (защита от обрезанного unzip-вывода)
+    elf_magic="$(dd if="$bin_source" bs=4 count=1 2>/dev/null | od -An -tx1 | tr -d ' \n\t')"
+    if [ "${elf_magic}" != "7f454c46" ]; then
+        echo -e "  ${red}Ошибка${reset}: Распакованный файл Xray не является ELF-бинарём (повреждён или не докачан)"
+        if [ -f "$install_dir/xray_bak" ]; then
+            mv "$install_dir/xray_bak" "$install_dir/xray"
+            echo -e "  ${yellow}Восстановлен${reset} предыдущий бинарник Xray"
+        fi
+        rm -f "$xray_archive"
+        rm -rf "${xtmp_dir}/xray"
+        return 1
+    fi
+
+    # Sanity-size: Xray binary весит 15+ MB, меньше 1 MB означает обрезанный файл
+    sz="$(wc -c < "$bin_source" 2>/dev/null)"
+    case "$sz" in
+        ''|*[!0-9]*) sz=0 ;;
+    esac
+    if [ "$sz" -lt 1048576 ]; then
+        echo -e "  ${red}Ошибка${reset}: Распакованный файл Xray подозрительно мал (${sz} B) — вероятно, обрезан"
+        if [ -f "$install_dir/xray_bak" ]; then
+            mv "$install_dir/xray_bak" "$install_dir/xray"
+            echo -e "  ${yellow}Восстановлен${reset} предыдущий бинарник Xray"
+        fi
+        rm -f "$xray_archive"
+        rm -rf "${xtmp_dir}/xray"
+        return 1
+    fi
+
+    mv_err="${xtmp_dir}/mv.err.$$"
+    if ! mv "$bin_source" "$install_dir/xray" 2>"${mv_err}"; then
+        _err="$(cat "${mv_err}" 2>/dev/null)"
+        rm -f "${mv_err}"
+        echo -e "  ${red}Ошибка${reset}: Не удалось переместить Xray в ${install_dir}"
+        [ -n "${_err}" ] && echo -e "  Подробности: ${_err}"
+        case "${_err}" in
+            *"No space left"*|*"ENOSPC"*|*"места"*)
+                echo -e "  ${yellow}Недостаточно свободного места${reset} на разделе с ${install_dir}"
+                ;;
+        esac
+        if [ -f "$install_dir/xray_bak" ]; then
+            mv "$install_dir/xray_bak" "$install_dir/xray"
+            echo -e "  ${yellow}Восстановлен${reset} предыдущий бинарник Xray"
+        fi
+        rm -f "$xray_archive"
+        rm -rf "${xtmp_dir}/xray"
+        return 1
+    fi
+    rm -f "${mv_err}"
+
     chmod +x "$install_dir/xray"
+
+    # Финальная проверка: бинарь существует, исполняем, запускается
+    if [ ! -x "$install_dir/xray" ] || ! "$install_dir/xray" version >/dev/null 2>&1; then
+        echo -e "  ${red}Ошибка${reset}: Установленный Xray не запускается (повреждён или несовместим с архитектурой)"
+        rm -f "$install_dir/xray"
+        rm -f "$xray_archive"
+        rm -rf "${xtmp_dir}/xray"
+        if [ -f "$install_dir/xray_bak" ]; then
+            mv "$install_dir/xray_bak" "$install_dir/xray"
+            echo -e "  ${yellow}Восстановлен${reset} предыдущий бинарник Xray"
+        fi
+        return 1
+    fi
+
+    rm -f "$install_dir/xray_bak"
     echo -e "  Xray ${green}успешно установлен${reset}"
 
     rm -f "$xray_archive"

--- a/scripts/xkeen
+++ b/scripts/xkeen
@@ -626,7 +626,7 @@ while [ $# -gt 0 ]; do
             info_xray
             info_version_xray
 
-            [ "$xray_installed" = "installed" ] && echo && echo -e "  В роутере установлен Xray версии ${yellow}$xray_current_version${reset}" && echo
+            [ "$xray_installed" = "installed" ] && echo && echo -e "  В роутере установлен Xray версии ${yellow}$xray_current_version${reset}"
             download_xray
 
             if [ -z "$bypass_xray" ]; then
@@ -701,7 +701,7 @@ while [ $# -gt 0 ]; do
             info_version_mihomo
             mihomo_was_installed="$mihomo_installed"
 
-            [ "$mihomo_installed" = "installed" ] && echo && echo -e "  В роутере установлен Mihomo версии ${yellow}$mihomo_current_version${reset}" && echo
+            [ "$mihomo_installed" = "installed" ] && echo && echo -e "  В роутере установлен Mihomo версии ${yellow}$mihomo_current_version${reset}"
             if ! download_mihomo; then
                 delete_tmp
                 exit 1

--- a/scripts/xkeen
+++ b/scripts/xkeen
@@ -168,7 +168,9 @@ while [ $# -gt 0 ]; do
             fi
 
             if [ -z "$bypass_xray" ]; then
-                install_xray
+                if ! install_xray; then
+                    bypass_xray="true"
+                fi
                 info_xray
             fi
 
@@ -245,7 +247,9 @@ while [ $# -gt 0 ]; do
             fi
 
             if [ -z "$bypass_mihomo" ]; then
-                install_mihomo
+                if ! install_mihomo; then
+                    bypass_mihomo="true"
+                fi
                 info_mihomo
             fi
 
@@ -626,7 +630,11 @@ while [ $# -gt 0 ]; do
             download_xray
 
             if [ -z "$bypass_xray" ]; then
-                install_xray
+                if ! install_xray; then
+                    delete_tmp
+                    echo -e "  ${red}Ошибка${reset}: Установка Xray не выполнена. См. сообщения выше"
+                    exit 1
+                fi
 
                 if [ "$xray_installed" = "installed" ]; then
                     echo -e "  Выполняется отмена регистрации предыдущей версии ${yellow}Xray${reset}"
@@ -700,12 +708,16 @@ while [ $# -gt 0 ]; do
             fi
 
             if [ -z "$bypass_mihomo" ]; then
-                install_mihomo
+                if ! install_mihomo; then
+                    delete_tmp
+                    echo -e "  ${red}Ошибка${reset}: Установка Mihomo не выполнена. См. сообщения выше"
+                    exit 1
+                fi
                 info_mihomo
 
                 if [ "$mihomo_installed" != "installed" ]; then
                     delete_tmp
-                    echo -e "  ${red}Ошибка${reset}: Mihomo не установлен, так как отсутствует обязательный Yq"
+                    echo -e "  ${red}Ошибка${reset}: Mihomo не установлен (отсутствует обязательный Yq или бинарь Mihomo)"
                     exit 1
                 elif [ "$mihomo_was_installed" = "installed" ]; then
                     echo -e "  Выполняется отмена регистрации предыдущей версии ${yellow}Mihomo${reset}"

--- a/scripts/xkeen
+++ b/scripts/xkeen
@@ -626,7 +626,7 @@ while [ $# -gt 0 ]; do
             info_xray
             info_version_xray
 
-            [ "$xray_installed" = "installed" ] && echo -e "  В роутере установлен Xray версии ${yellow}$xray_current_version${reset}" && echo
+            [ "$xray_installed" = "installed" ] && echo && echo -e "  В роутере установлен Xray версии ${yellow}$xray_current_version${reset}" && echo
             download_xray
 
             if [ -z "$bypass_xray" ]; then
@@ -701,7 +701,7 @@ while [ $# -gt 0 ]; do
             info_version_mihomo
             mihomo_was_installed="$mihomo_installed"
 
-            [ "$mihomo_installed" = "installed" ] && echo -e "  В роутере установлен Mihomo версии ${yellow}$mihomo_current_version${reset}" && echo
+            [ "$mihomo_installed" = "installed" ] && echo && echo -e "  В роутере установлен Mihomo версии ${yellow}$mihomo_current_version${reset}" && echo
             if ! download_mihomo; then
                 delete_tmp
                 exit 1
@@ -717,7 +717,7 @@ while [ $# -gt 0 ]; do
 
                 if [ "$mihomo_installed" != "installed" ]; then
                     delete_tmp
-                    echo -e "  ${red}Ошибка${reset}: Mihomo не установлен (отсутствует обязательный Yq или бинарь Mihomo)"
+                    echo -e "  ${red}Ошибка${reset}: Mihomo не установлен (отсутствует обязательный Yq или бинарник Mihomo)"
                     exit 1
                 elif [ "$mihomo_was_installed" = "installed" ]; then
                     echo -e "  Выполняется отмена регистрации предыдущей версии ${yellow}Mihomo${reset}"


### PR DESCRIPTION
Caller игнорировал return code install_mihomo/install_xray; info_* проверял -f вместо -x; stderr gzip/unzip заглушался; успех рапортовался даже когда бинарь не появлялся в /opt/sbin (например, при ENOSPC на маленьком разделе /opt).

Изменения:
- info_mihomo/info_xray: -f → -x (битый или не-exec файл больше не считается installed)
- install_mihomo/install_xray:
  - захват stderr gzip/unzip/mv в файлы, вывод "Подробности"
    + case на "No space left"/ENOSPC → дружелюбное сообщение "Недостаточно свободного места на разделе с /opt/sbin"
  - после распаковки: проверка ELF-сигнатуры (\x7fELF) через dd|od|tr и sanity-size >= 1 MB через wc -c
  - после chmod +x: запуск "mihomo -v" / "xray version" для финальной валидации (ловит несовместимость с CPU)
  - явный rm + restore из *_bak на всех failure-ветках
- scripts/xkeen:
  - install_* вызывается через if ! в -i/-um/-ux flows; сбой в -i выставляет bypass_*=true, в -um/-ux даёт delete_tmp + явный exit 1 с правильной причиной
  - в -um/-ux заменено misleading "отсутствует Yq" на "Установка Mihomo/Xray не выполнена. См. сообщения выше"

Никаких df-pre-check или фиксированных порогов свободного места: ошибка о нехватке места приходит от реальных операций ОС, не от самостоятельного решения скрипта.