### PR TITLE
fix(install): выбор softfloat-сборки Mihomo для mips32

### DIFF
--- a/scripts/_xkeen/04_tools/07_tools_downloaders/01_downloaders_mihomo.sh
+++ b/scripts/_xkeen/04_tools/07_tools_downloaders/01_downloaders_mihomo.sh
@@ -99,7 +99,11 @@ download_mihomo() {
                 download_yq="$yq_download_base_url/yq_linux_mipsle"
             ;;
             "mips32")
-                download_url="$URL_BASE/mihomo-linux-mips-hardfloat-$VERSION_ARG.gz"
+                if [ "$softfloat" = "true" ]; then
+                    download_url="$URL_BASE/mihomo-linux-mips-softfloat-$VERSION_ARG.gz"
+                else
+                    download_url="$URL_BASE/mihomo-linux-mips-hardfloat-$VERSION_ARG.gz"
+                fi
                 download_yq="$yq_download_base_url/yq_linux_mips"
             ;;
             *)


### PR DESCRIPTION
case-ветка "mips32" в downloaders_mihomo.sh всегда тянула hardfloat-сборку. На MIPS-роутерах без hardfloat FPU установленный Mihomo падал с illegal instruction (SIGILL).

Добавлен выбор softfloat/hardfloat по \$softfloat, симметрично с уже существующей логикой для mips32le. Дефолтное поведение не меняется: \$softfloat пуст для mips32 в текущем 03_info_cpu.sh, поэтому без явного переопределения остаётся hardfloat как раньше.

Расширение автодетекции softfloat для mips32-моделей KN-* — отдельный issue/PR, требует upstream-знания о CPU.