### PR TITLE
fix(docs): картинки гайда установки и список в forkinfo на Pages

### DIFF
--- a/.github/scripts/stage-docs.sh
+++ b/.github/scripts/stage-docs.sh
@@ -100,6 +100,13 @@ for src in "$ROOT"/wiki/*.md; do
     esac
 done
 
+# Картинки гайдов (wiki/images/*) → site_src/guides/images/.
+# Без этого <img src="images/..."> на страницах guides отдаёт 404.
+if [ -d "$ROOT/wiki/images" ]; then
+    mkdir -p "$SRC/guides/images"
+    cp "$ROOT"/wiki/images/* "$SRC/guides/images/"
+fi
+
 # docs/*.md → авто-цикл. Исключения те же (_*.md, .gitignore — release-notes/ авто-скип).
 # Спецслучаи:
 #   README.md   → site_src/dev/index.md (раздел «Для разработчиков»)
@@ -169,6 +176,10 @@ for f in "$SRC"/guides/*.md; do
         -e 's|](DNS-over-VLESS)|](DNS-over-VLESS.md)|g' \
         -e 's|](Маршрутизация-по-DSCP)|](Маршрутизация-по-DSCP.md)|g' \
         "$f"
+    # Сырые <img src="images/..."> → markdown ![alt](images/...): mkdocs сам
+    # перепишет относительный путь под use_directory_urls и провалидирует файл
+    # (--strict). Сырой HTML mkdocs не трогает, поэтому путь оставался бы битым.
+    sed -i 's|<img src="\(images/[^"]*\)" alt="\([^"]*\)">|![\2](\1)|g' "$f"
 done
 
 # (4) Относительные ссылки docs/* → ../scripts/, ../.github/, ../test/, ../install.sh, ../wiki/

--- a/wiki/Forkinfo.md
+++ b/wiki/Forkinfo.md
@@ -1,6 +1,7 @@
 ## Подробное описание изменений форка по сравнению с оригинальным XKeen
 
 Добавлено:
+
 - Совместимость с прошивкой KeeneticOS 5+
 - Поддержка ядра Mihomo и смена ядра проксирования (Xray/Mihomo) параметрами запуска `-xray` и `-mihomo`
 - Реализована работа с пользовательскими политиками [подробнее](https://github.com/jameszeroX/XKeen/wiki/Configuration#пользовательские-политики)
@@ -35,7 +36,8 @@
 - Параметр запуска `-fd` для контроля открытых файловых дескрипторов [подробнее](https://github.com/jameszeroX/XKeen/wiki/Configuration#контроль-файловых-дескрипторов)
 - Параметр запуска `-extmsg` для вывода расширенной информации при запуске прокси-клиента
 
-Измененено:
+Изменено:
+
 - Исправлено добавление портов в исключения (ранее команду `xkeen -ape` нужно было прерывать по ctrl+c)
 - Исправлена совместная работа режима TProxy и socks5 (ранее Xkeen запускался в Mixed режиме, что приводило к неработоспособности прозрачного проксирования)
 - Исправлен автозапуск XKeen при старте роутера (ранее XKeen в некоторых случаях не запускался или запускался для всего устройства, а не только для своей политики - [FAQ п.12](https://github.com/jameszeroX/XKeen/wiki/FAQ#12))
@@ -67,6 +69,7 @@
 - Доработки согласно PR [#33](https://github.com/jameszeroX/XKeen/pull/33), [#34](https://github.com/jameszeroX/XKeen/pull/34), [#35](https://github.com/jameszeroX/XKeen/pull/35), [#36](https://github.com/jameszeroX/XKeen/pull/36), [#37](https://github.com/jameszeroX/XKeen/pull/37), [#38](https://github.com/jameszeroX/XKeen/pull/38), [#39](https://github.com/jameszeroX/XKeen/pull/39), [#40](https://github.com/jameszeroX/XKeen/pull/40), [#41](https://github.com/jameszeroX/XKeen/pull/41), [#42](https://github.com/jameszeroX/XKeen/pull/42), [#43](https://github.com/jameszeroX/XKeen/pull/43), [#44](https://github.com/jameszeroX/XKeen/pull/44), [#45](https://github.com/jameszeroX/XKeen/pull/45), [#46](https://github.com/jameszeroX/XKeen/pull/46), [#47](https://github.com/jameszeroX/XKeen/pull/47), [#48](https://github.com/jameszeroX/XKeen/pull/48), [#49](https://github.com/jameszeroX/XKeen/pull/49), [#50](https://github.com/jameszeroX/XKeen/pull/50), [#51](https://github.com/jameszeroX/XKeen/pull/51), [#52](https://github.com/jameszeroX/XKeen/pull/52) - [@oviron](https://github.com/oviron)
 
 Удалено:
+
 - Поддержка внешнего файла `/opt/etc/xkeen_exclude.lst` c IP-адресами и подсетями для исключения из проксирования
 - Возможность установки GeoSite Antizapret (база повреждена в репозитории)
 - Конфигурационный файл `02_transport.json` (не используется новыми ядрами xray-core)


### PR DESCRIPTION
Две ошибки рендера MkDocs-сайта (GitHub Pages):

1. /guides/Порядок-установки/ — картинки 404. stage-docs.sh не копировал wiki/images/, а сырой <img src="images/..."> не резолвится под use_directory_urls и не переписывается mkdocs. Теперь копируем картинки в site_src/guides/images/ и конвертируем <img> в markdown ![](), чтобы mkdocs сам переписал путь и провалидировал файл (--strict).

2. /forkinfo/ — текст слипался в одну строку. python-markdown требует пустую строку перед списком (в отличие от GFM на GitHub), иначе пункты склеиваются в один <p>. Добавлены пустые строки перед списками Добавлено/Изменено/Удалено. Заодно опечатка «Измененено» → «Изменено».