### PR TITLE
Исправить повторный transparent-захват DSCP 61 force proxy

### DIFF
--- a/scripts/_xkeen/02_install/07_install_register/04_register_init.sh
+++ b/scripts/_xkeen/02_install/07_install_register/04_register_init.sh
@@ -1378,6 +1378,16 @@ if pidof "$name_client" >/dev/null; then
                 ipt -I "$chain" -m dscp --dscp "$dscp" $comment -j RETURN >/dev/null 2>&1
             done
         fi
+
+        # DSCP force-proxy обрабатывается отдельной chain'ой xkeen_force в
+        # mangle/PREROUTING. Если не выйти здесь из обычной chain для тех же
+        # протоколов, пакет позже попадёт в штатный REDIRECT/TPROXY path и
+        # потеряет original dst.
+        if [ -n "$port_dscp_force_proxy" ] && [ "$mode_dscp_force_proxy" = "tproxy" ]; then
+            for net in $network_dscp_force_proxy; do
+                ipt -I "$chain" 1 -p "$net" -m dscp --dscp "$dscp_force_proxy" $comment -j RETURN >/dev/null 2>&1
+            done
+        fi
     }
 
     # Настройка таблицы маршрутов


### PR DESCRIPTION
Исправлен повторный захват трафика с DSCP 61 обычной transparent-цепочкой.

Что было:
`dscp-force-proxy` получал уже локальный `192.168.*.*:61219` вместо original destination, потому что после force-path пакет повторно попадал в штатный `REDIRECT/TPROXY` path.

Что изменено:
для `DSCP 61` добавлен ранний `RETURN` из обычной `${name_chain}` только для протоколов, объявленных у `dscp-force-proxy`.

Результат:
трафик с `DSCP 61` остаётся только в force-path и приходит в inbound `dscp-force-proxy` с original destination.