### PR TITLE
Оптимизировать генерацию TProxy netfilter-правил

### DIFF
--- a/scripts/_xkeen/02_install/07_install_register/04_register_init.sh
+++ b/scripts/_xkeen/02_install/07_install_register/04_register_init.sh
@@ -1725,11 +1725,9 @@ if pidof "$name_client" >/dev/null; then
                 [ "$table" = "mangle" ] && [ "$net" != "udp" ] && continue
             fi
 
-            if [ "$mode_proxy" = "TProxy" ]; then
-                proto_match=""
-            else
-                proto_match="-p $net"
-            fi
+            proto_match="-p $net"
+            all_ports_proto_match=""
+            [ "$mode_proxy" = "TProxy" ] && all_ports_proto_match="$proto_match"
 
             for dscp in $dscp_proxy; do
                 set -- -m conntrack ! --ctstate INVALID $proto_match -m dscp --dscp "$dscp" $comment -j "$name_chain"

--- a/scripts/_xkeen/02_install/07_install_register/04_register_init.sh
+++ b/scripts/_xkeen/02_install/07_install_register/04_register_init.sh
@@ -1562,10 +1562,10 @@ if pidof "$name_client" >/dev/null; then
                 ;;
             TProxy)
                 ipt -I "$chain" 1 -m conntrack --ctstate DNAT $comment -j RETURN >/dev/null 2>&1
+                add_ipset_exclude ext_exclude hash:ip
+                add_ipset_exclude user_exclude hash:net
+                add_geo_exclude
                 for net in $network_tproxy; do
-                    add_ipset_exclude ext_exclude hash:ip
-                    add_ipset_exclude user_exclude hash:net
-                    add_geo_exclude
                     ipt -A "$chain" -p "$net" -m socket --transparent $comment -j MARK --set-mark "$table_mark" >/dev/null 2>&1
                     ipt -A "$chain" -p "$net" -m mark ! --mark 0 $comment -j CONNMARK --save-mark >/dev/null 2>&1
                     ipt -A "$chain" -p "$net" $comment -j TPROXY --on-ip "$proxy_ip" --on-port "$port_tproxy" --tproxy-mark "$table_mark" >/dev/null 2>&1

--- a/scripts/_xkeen/02_install/07_install_register/04_register_init.sh
+++ b/scripts/_xkeen/02_install/07_install_register/04_register_init.sh
@@ -1828,11 +1828,7 @@ USER_POLICIES_EOF
                 [ "$table" = "mangle" ] && [ "$net" != "udp" ] && continue
             fi
 
-            if [ "$mode_proxy" = "TProxy" ]; then
-                proto_match=""
-            else
-                proto_match="-p $net"
-            fi
+            proto_match="-p $net"
 
             set -- -m conntrack ! --ctstate INVALID $proto_match $comment -j "$out_chain"
             ipt -A OUTPUT "$@" >/dev/null 2>&1

--- a/scripts/_xkeen/02_install/07_install_register/04_register_init.sh
+++ b/scripts/_xkeen/02_install/07_install_register/04_register_init.sh
@@ -1750,7 +1750,7 @@ if pidof "$name_client" >/dev/null; then
                 pports=$(echo "$pports" | tr -d ' \r\n')
 
                 if [ "$pmode" = "all" ]; then
-                    set -- -m connmark --mark 0x"$pmark" -m conntrack ! --ctstate INVALID $comment -j "$name_chain"
+                    set -- -m connmark --mark 0x"$pmark" -m conntrack ! --ctstate INVALID $all_ports_proto_match $comment -j "$name_chain"
                     ipt -A PREROUTING "$@" >/dev/null 2>&1
                 elif [ "$pmode" = "include" ]; then
                     add_multiport_rules "$family" "$table" "$net" "0x$pmark" "$pports" "$name_chain"
@@ -1775,7 +1775,7 @@ USER_POLICIES_EOF
                     ipt -A PREROUTING "$@" >/dev/null 2>&1
                 else
                     # Политика xkeen, когда порты не указаны (проксирование на всех портах)
-                    set -- -m connmark --mark "$policy_mark" -m conntrack ! --ctstate INVALID $comment -j "$name_chain"
+                    set -- -m connmark --mark "$policy_mark" -m conntrack ! --ctstate INVALID $all_ports_proto_match $comment -j "$name_chain"
                     ipt -A PREROUTING "$@" >/dev/null 2>&1
                 fi
             # НЕТ политики xkeen
@@ -1790,7 +1790,7 @@ USER_POLICIES_EOF
                     ipt -A PREROUTING "$@" >/dev/null 2>&1
                 # Если нет ни xkeen, ни пользовательских политик -> перехватываем всё
                 else
-                    set -- -m conntrack ! --ctstate INVALID $comment -j "$name_chain"
+                    set -- -m conntrack ! --ctstate INVALID $all_ports_proto_match $comment -j "$name_chain"
                     ipt -A PREROUTING "$@" >/dev/null 2>&1
                 fi
             fi


### PR DESCRIPTION
## Что изменено

Этот PR оптимизирует генерацию netfilter/iptables-правил для TProxy-режима без изменения поведения Redirect и Hybrid.

Изменения разбиты на атомарные коммиты:

### 1. `netfilter: deduplicate TProxy ipset excludes`

В TProxy-chain правила `ext_exclude`, `user_exclude` и `geo_exclude` вынесены из цикла по `network_tproxy`.

Раньше при `network_tproxy="tcp udp"` один и тот же набор ipset-исключений добавлялся дважды. Эти правила не зависят от протокола и делают `RETURN` до `MARK/TPROXY`, поэтому повторный блок не менял результат, но удлинял chain.

Что улучшает:

- цепочка `xkeen` в TProxy становится короче;
- direct/excluded трафик проходит меньше повторяющихся проверок;
- порядок обработки сохраняется: ipset-исключения всё ещё срабатывают раньше `MARK`, `CONNMARK --save-mark` и `TPROXY`.

### 2. `netfilter: limit TProxy PREROUTING jumps to tcp udp`

В TProxy-режиме jump'ы из `PREROUTING` в `xkeen` больше не создаются без указания протокола.

Раньше в TProxy `proto_match` становился пустым, из-за чего могли появляться широкие правила вида:

```sh
-A PREROUTING -m conntrack ! --ctstate INVALID ... -j xkeen
```

Теперь они создаются отдельно для `tcp` и `udp`:

```sh
-A PREROUTING ... -p tcp ... -j xkeen
-A PREROUTING ... -p udp ... -j xkeen
```

Почему это безопасно:

Внутри TProxy-chain реальные действия `MARK`, `CONNMARK` и `TPROXY` создаются только для `tcp/udp`. Общий jump не давал полезной обработки другим протоколам, а только добавлял лишний проход по chain.

Что улучшает:

- убирает лишние заходы в `xkeen` для неподходящих протоколов;
- убирает дублирующие широкие jump'ы при `network_tproxy="tcp udp"`;
- делает вход в TProxy-chain согласованным с тем, какие протоколы реально обрабатываются дальше.

### 3. `netfilter: scope TProxy all-policy jumps by protocol`

Для TProxy добавлен протокольный матч в ветках, где проксирование применяется ко всем портам:

- пользовательская политика с режимом `all`;
- обычная политика xkeen без `port_proxying` / `port_exclude`;
- no-policy catch-all режим.

Для Redirect и Hybrid поведение не меняется: протокольный матч добавляется только в TProxy.

Что улучшает:

- закрывает оставшиеся широкие TProxy `PREROUTING` jump'ы;
- сохраняет поведение `port_proxying` и `port_exclude`, потому что эти ветки уже используют `add_multiport_rules` с явным `-p "$net"`;
- делает все TProxy all-traffic сценарии протокольно-точными.

### 4. `netfilter: limit TProxy OUTPUT jumps to tcp udp`

В TProxy `OUTPUT` для `proxy_router=on` jump в `${name_chain}_out` теперь создаётся с `-p tcp` / `-p udp`.

Раньше локальный/router traffic мог заходить в `xkeen_out` через общий jump без протокола, хотя дальше в TProxy OUTPUT-chain выполняется только `MARK` для `tcp/udp`.

Что улучшает:

- уменьшает лишнюю обработку в OUTPUT chain;
- не отправляет неподходящие протоколы в `xkeen_out`;
- делает OUTPUT-логику симметричной PREROUTING-логике.
