### PR TITLE
fix: редиректить вывод ядра в /dev/null во всех ветках proxy_start

### DIFF
--- a/scripts/_xkeen/02_install/07_install_register/04_register_init.sh
+++ b/scripts/_xkeen/02_install/07_install_register/04_register_init.sh
@@ -3033,7 +3033,7 @@ proxy_start() {
                             nohup "$name_client" run >/dev/null 2>&1 &
                             unset fd_out
                         else
-                            "$name_client" run &
+                            "$name_client" run >/dev/null 2>&1 &
                         fi
                     ;;
                     mihomo)
@@ -3043,7 +3043,7 @@ proxy_start() {
                             nohup "$name_client" >/dev/null 2>&1 &
                             unset fd_out
                         else
-                            "$name_client" &
+                            "$name_client" >/dev/null 2>&1 &
                         fi
                         ;;
                     *) log_error_terminal "Неизвестный прокси-клиент: ${yellow}$name_client${reset}" ;;


### PR DESCRIPTION
В `proxy_start` ядро запускается из нескольких веток. Почти все глушат вывод
в `/dev/null`. Две из них, xray и mihomo в обычном (не-detach) режиме, этого не делают:

```sh
"$name_client" run &   # xray
"$name_client" &       # mihomo
```

Без редиректа ядро наследует stdout/stderr процесса, который дёрнул рестарт. Если
этот процесс пишет свой вывод в файл, ядро потом до следующего рестарта льёт туда
весь свой лог, и файл растёт без предела.

Напоролся, когда рестарт у меня вызывается из скрипта, логирующего вывод в файл:
за три дня между рестартами туда натекло ~140 МБ.

Похоже на #40, но там ядро держалось за сессию вызвавшего, а здесь просто
унаследованный дескриптор вывода, detach от сессии это не лечит.

Дописал `>/dev/null 2>&1` в обе ветки, как в остальных. `sh -n` и `shellcheck` чисты.
