### PR TITLE
fix: shrink TProxy outage window on NDM netfilter rewrite (DHCP renew)

### DIFF
--- a/scripts/_xkeen/02_install/07_install_register/04_register_init.sh
+++ b/scripts/_xkeen/02_install/07_install_register/04_register_init.sh
@@ -1908,6 +1908,7 @@ configure_firewall() {
 #!/bin/sh
 # XKeen: Auto-generated file. DO NOT EDIT!
 [ -f /tmp/xkeen_ready ] || exit 0
+case "${table:-}" in filter|raw) exit 0 ;; esac
 EOL
 
     # Securely inject variables into the script
@@ -1989,6 +1990,11 @@ if pidof "$name_client" >/dev/null; then
     # в FORWARD, где штатно дропается NDM-цепочкой _NDM_HOTSPOT_FWD.
     # Хук перезапускается NDM при netfilter rewrite, schedule.d дёргает этот же
     # скрипт на start/stop расписаний — список MAC всегда актуален.
+    # Вызывается ПОСЛЕ _xkeen_apply: NDM к моменту вызова хука уже снёс
+    # xkeen-цепочки, и каждая миллисекунда до их восстановления — окно, в
+    # котором проксируемый трафик идёт мимо политики. curl к hotspot API
+    # (до 2+5 c таймаутов) в этом окне недопустим; правилам достаточно,
+    # чтобы ipset существовал — членство синхронизируется после.
     _xkeen_sync_deny_mac_ipset() {
         command -v ipset >/dev/null 2>&1 || return 0
         ipset create "$name_ipset_deny_mac" hash:mac -exist 2>/dev/null || return 0
@@ -2009,7 +2015,7 @@ if pidof "$name_client" >/dev/null; then
         ipset swap "$_tmp" "$name_ipset_deny_mac" 2>/dev/null
         ipset destroy "$_tmp" 2>/dev/null
     }
-    _xkeen_sync_deny_mac_ipset
+    command -v ipset >/dev/null 2>&1 && ipset create "$name_ipset_deny_mac" hash:mac -exist 2>/dev/null
 
     # Аккумулируем правила в строки, применяем атомарно одним
     # iptables-restore --noflush на (family, table) в _xkeen_apply.
@@ -2330,6 +2336,23 @@ if pidof "$name_client" >/dev/null; then
         done
         [ "$ip_version" = "4" ] && rm -f "/tmp/noinet"
 
+        # NDM при netfilter rewrite (в т.ч. на каждый DHCP renew) не трогает
+        # ни ip rule, ни table $table_id — безусловный flush ниже рвал
+        # установленные TProxy-потоки без причины. Если целевое состояние
+        # (local default + копия non-default маршрутов source_table + fwmark
+        # rule) уже действует — не трогаем. Любое расхождение -> полная
+        # пересборка, как раньше.
+        _cur_routes=$(ip -"$ip_version" route show table "$table_id" 2>/dev/null)
+        _want_routes=$(ip -"$ip_version" route show table "$source_table" 2>/dev/null | \
+            grep -v '^default\|^unreachable\|^blackhole')
+        if [ -n "$_cur_routes" ] && \
+           printf '%s\n' "$_cur_routes" | grep -q '^local default dev lo' && \
+           [ "$(printf '%s\n' "$_cur_routes" | grep -v '^local default dev lo' | sort)" = \
+             "$(printf '%s\n' "$_want_routes" | sort)" ] && \
+           ip -"$ip_version" rule show 2>/dev/null | grep -q "fwmark $table_mark lookup $table_id"; then
+            return 0
+        fi
+
         ip -"$ip_version" rule del fwmark "$table_mark" lookup "$table_id" >/dev/null 2>&1 || true
         ip -"$ip_version" route flush table "$table_id" >/dev/null 2>&1 || true
         ip -"$ip_version" route add local default dev lo table "$table_id" >/dev/null 2>&1 || true
@@ -2566,6 +2589,49 @@ USER_POLICIES_EOF
         done
     }
 
+    # Лёгкий путь. NDM зовёт netfilter.d на каждую пересобранную (type, table)
+    # пару, schedule.d дёргает хук ради deny-MAC ipset — в этих вызовах наши
+    # правила часто уже на месте. Если все xkeen-цепочки и tagged-правила
+    # уцелели, полная пересборка не нужна: только идемпотентные маршруты и
+    # ре-синхронизация deny-MAC. Любое сомнение -> полная пересборка.
+    _xkeen_hook_tables=""
+    [ -n "$port_tproxy" ] && _xkeen_hook_tables="$table_tproxy"
+    [ -n "$port_redirect" ] && [ "$table_redirect" != "$table_tproxy" ] && \
+        _xkeen_hook_tables="$_xkeen_hook_tables $table_redirect"
+
+    _xkeen_family_intact() {
+        _bin="$1"
+        for _tbl in $_xkeen_hook_tables; do
+            [ "$("$_bin" -w -t "$_tbl" -S "$name_chain" 2>/dev/null | wc -l)" -gt 1 ] || return 1
+            "$_bin" -w -t "$_tbl" -S PREROUTING 2>/dev/null | grep -q "$comment_tag" || return 1
+            if [ "$proxy_router" = "on" ]; then
+                "$_bin" -w -t "$_tbl" -S OUTPUT 2>/dev/null | grep -q "$comment_tag" || return 1
+            fi
+        done
+        if [ "$aghfix" = "on" ] && ! { [ "$file_dns" = "true" ] && [ "$proxy_dns" = "on" ]; }; then
+            "$_bin" -w -t nat -S _NDM_HOTSPOT_DNSREDIR 2>/dev/null | grep -q "$comment_tag" || return 1
+        fi
+        return 0
+    }
+
+    _xkeen_rules_intact() {
+        [ -n "$_xkeen_hook_tables" ] || return 1
+        if [ "$iptables_supported" = "true" ]; then
+            _xkeen_family_intact iptables || return 1
+        fi
+        if [ "$ip6tables_supported" = "true" ]; then
+            _xkeen_family_intact ip6tables || return 1
+        fi
+        return 0
+    }
+
+    if _xkeen_rules_intact; then
+        [ "$iptables_supported" = "true" ] && configure_route 4
+        [ "$ip6tables_supported" = "true" ] && configure_route 6
+        _xkeen_sync_deny_mac_ipset
+        exit 0
+    fi
+
     if [ -n "$port_donor" ] || [ -n "$port_exclude" ]; then
         [ "$file_dns" = "true" ] && [ "$proxy_dns" = "on" ] && [ -n "$port_donor" ] && port_donor="53,$port_donor"
     fi
@@ -2609,6 +2675,10 @@ USER_POLICIES_EOF
     # Атомарно применяем все аккумулированные правила одним
     # iptables-restore --noflush per (family, table).
     _xkeen_apply
+
+    # Медленная часть (curl к hotspot API) — строго после восстановления
+    # правил: см. комментарий у _xkeen_sync_deny_mac_ipset.
+    _xkeen_sync_deny_mac_ipset
 else
     [ -f "/tmp/xkeen_starting.lock" ] && exit 0
     touch "/tmp/xkeen_starting.lock"


### PR DESCRIPTION
## Проблема

На провайдерах с коротким DHCP lease (встречается 300 с и меньше — renew каждые ~2.5 минуты) соединения через прокси периодически рвутся, хотя WAN IP не меняется. Похоже на #24.

Разобрал механику на KeeneticOS 5.x (TProxy + mihomo), наблюдая состояние netfilter поллером с шагом 0.2 с. На каждый DHCP renew — даже когда IP остался тем же — происходит следующее:

1. NDM пересобирает netfilter и при этом **сносит цепочки xkeen целиком**, а `netfilter.d/proxy.sh` вызывает уже после.
2. Пока хук не восстановил правила, цепочек нет **~1.0–1.5 секунды**. Всё это время:
   - **новые соединения уходят в обход прокси с реальным IP** — тихое окно деанонимизации каждые 2.5 минуты, пользователь его никак не видит;
   - установленные соединения через прокси ломаются: их пакеты уходят напрямую, удалённая сторона отвечает RST — отсюда и «рвутся закачки/стримы/туннели».
3. Само окно можно сильно ужать, потому что бóльшую его часть создаёт хук, а не прошивка. Из ~1.0–1.5 с лишь ~0.3 с — задержка между сносом и запуском хука (сторона NDM). Дальше хук первым делом идёт в hotspot API (`curl --connect-timeout 2 -m 5` + jq в `_xkeen_sync_deny_mac_ipset`) и только потом восстанавливает правила.
4. Отдельная беда: `ip rule` (fwmark) и таблицу маршрутизации 111 NDM при rewrite **не трогает** — они спокойно переживают событие. Но `configure_route()` на каждый вызов безусловно выполняет `rule del` + `route flush table 111` + пересоздание. То есть каждые 2.5 минуты policy routing рвётся ещё раз уже нашими руками — это та же механика, что даёт EPERM на маркированных пакетах в #24.

## Что меняется

Все правки — в шаблоне хука в `configure_firewall()`:

- **Сначала правила, потом медленное.** `_xkeen_sync_deny_mac_ipset` (curl + jq) вызывается после `_xkeen_apply`. Правилам достаточно, чтобы ipset существовал — быстрый `ipset create -exist` остаётся до применения, состав сета доливается после.
- **`configure_route()` идемпотентна.** Разрушительная последовательность del/flush/add выполняется только если фактическое состояние (fwmark-rule, local default, копия non-default маршрутов source table) отличается от целевого. Любое расхождение — полная пересборка, как раньше.
- **Ранний выход для `table=filter|raw`.** NDM вызывает netfilter.d на каждую пересобранную таблицу, а правила xkeen живут только в mangle/nat.
- **Лёгкий путь, когда всё цело.** Если все xkeen-цепочки и tagged-правила на месте (вызов из schedule.d, событие по незатронутой таблице) — только идемпотентная проверка маршрутов и ресинк deny-MAC ipset, без полной пересборки.

## Эффект

- Окно без правил (и окно утечки реального IP) на каждый renew сокращается с ~1.0–1.5 с до ~0.4–0.6 с; остаток — задержка на стороне NDM, из Entware её не убрать.
- Полностью исчезают безусловные разрывы table 111 / fwmark-rule.
- Обрывы установленных соединений становятся заметно реже: полсекунды TCP обычно переживает за счёт ретрансмитов, полторы — почти никогда.

Поведение при любом расхождении состояния прежнее (полная пересборка), так что регрессий быть не должно. Синтаксис сгенерированного хука проверен `sh -n` (TProxy-конфигурация). Если нужно прогнать другие режимы (Redirect/Hybrid, IPv6, proxy_router=on) или собрать логи с живого renew — сделаю.
