### PR TITLE
feat: set GOMEMLIMIT for mihomo based on device RAM

### DIFF
--- a/scripts/_xkeen/02_install/07_install_register/04_register_init.sh
+++ b/scripts/_xkeen/02_install/07_install_register/04_register_init.sh
@@ -2698,6 +2698,19 @@ else
         ;;
         mihomo)
             export CLASH_HOME_DIR="$directory_configs_app"
+            # mihomo — Go-приложение: без GOMEMLIMIT сборщик мусора не
+            # стремится возвращать память ОС, и на роутерах RSS ползёт
+            # вверх до OOM. Мягкий лимит в половину RAM (минимум 64MiB)
+            # заставляет GC ужиматься заранее. Уже заданный извне
+            # GOMEMLIMIT не игнорируется.
+            if [ -z "$GOMEMLIMIT" ]; then
+                _mem_kb=$(awk '/^MemTotal:/{print $2}' /proc/meminfo 2>/dev/null)
+                if [ -n "$_mem_kb" ] && [ "$_mem_kb" -gt 0 ] 2>/dev/null; then
+                    _goml=$(( _mem_kb / 2048 ))
+                    [ "$_goml" -lt 64 ] && _goml=64
+                    export GOMEMLIMIT="${_goml}MiB"
+                fi
+            fi
             "$name_client" >/dev/null 2>&1 &
         ;;
     esac
@@ -3113,6 +3126,17 @@ proxy_start() {
                     ;;
                     mihomo)
                         export CLASH_HOME_DIR="$directory_configs_app"
+                        # См. комментарий у запуска mihomo в netfilter-хуке:
+                        # мягкий лимит памяти для Go GC, половина RAM,
+                        # минимум 64MiB, внешний GOMEMLIMIT не игнорируется.
+                        if [ -z "$GOMEMLIMIT" ]; then
+                            _mem_kb=$(awk '/^MemTotal:/{print $2}' /proc/meminfo 2>/dev/null)
+                            if [ -n "$_mem_kb" ] && [ "$_mem_kb" -gt 0 ] 2>/dev/null; then
+                                _goml=$(( _mem_kb / 2048 ))
+                                [ "$_goml" -lt 64 ] && _goml=64
+                                export GOMEMLIMIT="${_goml}MiB"
+                            fi
+                        fi
                         apply_fd_limit
                         if [ -n "$fd_out" ]; then
                             nohup "$name_client" >/dev/null 2>&1 &


### PR DESCRIPTION
## Проблема

mihomo — Go-приложение. Без `GOMEMLIMIT` сборщик мусора Go не стремится возвращать освобождённую память ОС: на десктопе это незаметно, а на роутере с 256–1024 МБ RAM RSS процесса под нагрузкой ползёт вверх, пока не приходит OOM-killer — и прокси молча умирает. Симптом хорошо известен пользователям mihomo на embedded-устройствах; сейчас единственное решение — вручную править файл автозапуска, и эта правка теряется при каждом обновлении/пересоздании init-скрипта.

## Что меняется

В обоих местах запуска mihomo (штатный старт и fallback-запуск из netfilter-хука) перед стартом экспортируется мягкий лимит памяти:

- `GOMEMLIMIT` = половина `MemTotal` из `/proc/meminfo`, но не меньше 64MiB;
- уже заданный в окружении `GOMEMLIMIT` **не игнорируется** — кто тюнит вручную, сохраняет полный контроль;
- `GOGC` намеренно не трогается: `GOMEMLIMIT` сам по себе ограничивает рост кучи, а низкий `GOGC` на слабых CPU дорого стоит постоянными циклами GC.

## Преимущества

- Устраняется главный источник «mihomo съел всю память и умер» на маломощных устройствах — без единого действия со стороны пользователя.
- Лимит мягкий (Go GC начинает ужиматься при приближении к нему), а не жёсткий cap: при реальном дефиците памяти mihomo продолжает работать, просто агрессивнее собирает мусор.
- Значение адаптивное: половина RAM разумна и для Giga с 1 ГБ, и для младших моделей с 256 МБ.
- Ручные правки автозапуска ради GOMEMLIMIT больше не нужны — и не теряются при обновлениях.
