### PR TITLE
fix: serialize concurrent netfilter.d hook invocations

### DIFF
--- a/scripts/_xkeen/02_install/07_install_register/04_register_init.sh
+++ b/scripts/_xkeen/02_install/07_install_register/04_register_init.sh
@@ -1984,6 +1984,33 @@ restart_script() {
 
 if pidof "$name_client" >/dev/null; then
 
+    # Сериализация прогонов хука. NDM вызывает netfilter.d конкурентно —
+    # по событию на каждую пересобранную (type, table) пару, плюс schedule.d.
+    # Два параллельных прогона опасны: delete-list строится по снапшоту
+    # iptables-save, и restore соседа может отвергнуть весь блоб целиком.
+    # mkdir — единственный атомарный lock в busybox-ash. Не дождались за
+    # ~5 с — держатель уже применил актуальное состояние, выходим; если
+    # правила всё же не целы, следующее событие NDM их доставит.
+    _xkeen_nf_lock="/tmp/xkeen_netfilter.lock.d"
+    _xkeen_lock_owned=""
+    _lock_try=0
+    while [ "$_lock_try" -lt 50 ]; do
+        if mkdir "$_xkeen_nf_lock" 2>/dev/null; then
+            _xkeen_lock_owned=1
+            printf '%s' "$$" > "$_xkeen_nf_lock/pid"
+            trap 'rm -rf "$_xkeen_nf_lock"' EXIT INT TERM
+            break
+        fi
+        _lock_pid=$(cat "$_xkeen_nf_lock/pid" 2>/dev/null)
+        if [ -n "$_lock_pid" ] && ! kill -0 "$_lock_pid" 2>/dev/null; then
+            rm -rf "$_xkeen_nf_lock" 2>/dev/null
+            continue
+        fi
+        _lock_try=$((_lock_try + 1))
+        usleep 100000 2>/dev/null || sleep 1
+    done
+    [ -n "$_xkeen_lock_owned" ] || exit 0
+
     # Динамическая синхронизация ipset с deny-MAC из hotspot API.
     # Закрывает обход built-in политики «Без доступа в интернет» при включенном
     # проксировании: PREROUTING на эти MAC делает RETURN до TPROXY, пакет идёт


### PR DESCRIPTION
## Проблема

NDM вызывает скрипты `netfilter.d` конкурентно — отдельным событием на каждую пересобранную пару (type, table); параллельно тот же скрипт дёргает schedule.d-хук. Несколько экземпляров хука спокойно работают одновременно, и это небезопасно:

- delete-list устаревших правил строится по снапшоту `iptables-save`;
- сосед, применивший свой блоб между снапшотом и restore, инвалидирует этот снапшот;
- `iptables-restore` отвергает **весь** батч целиком — таблица остаётся без правил xkeen до следующего события netfilter.

Гонка редкая, но воспроизводимая именно в самые «горячие» моменты (пересборка нескольких таблиц одним событием), и после неё прокси молча перестаёт перехватывать трафик.

## Что меняется

Ветка работающего клиента берёт lock через `mkdir` в /tmp — единственный атомарный примитив в busybox-ash; тот же паттерн уже используется в проекте для cold-start guard:

- владелец пишет PID в lock-директорию; конкурент с мёртвым владельцем забирает lock себе (защита от зависших держателей);
- конкурент ждёт до ~5 с (50 × 100 мс) и, если lock всё ещё занят, выходит — держатель только что применил актуальное состояние, дублировать работу незачем;
- lock снимается trap-ом на EXIT/INT/TERM, включая ранний выход по fast-path.

## Преимущества

- Класс «прокси молча отвалился после пересборки файрвола» из-за гонки снапшотов закрывается полностью.
- Конкурент, дождавшийся освобождения lock, попадает в intact-fast-path (правила уже на месте) и завершается почти бесплатно — сериализация не добавляет заметной задержки.
- На штатном одиночном прогоне оверхед — один `mkdir` и один `rm -rf`.
- Синергия с ретраем restore: ретрай закрывает гонку с внешними модификациями таблиц (NDM), lock — гонку хука с самим собой.
