### PR TITLE
perf: cache netfilter rule blobs between hook runs

### DIFF
--- a/scripts/_xkeen/02_install/07_install_register/04_register_init.sh
+++ b/scripts/_xkeen/02_install/07_install_register/04_register_init.sh
@@ -2632,6 +2632,70 @@ USER_POLICIES_EOF
         exit 0
     fi
 
+    # Кэш готовых restore-блобов. Набор правил полностью детерминирован
+    # конфигурацией, запечённой в этот файл при генерации, — на каждом
+    # прогоне пересобирать его сотнями shell-вызовов незачем. После полной
+    # сборки блобы сохраняются в /tmp с ключом = md5 самого хука: любое
+    # изменение конфигурации перегенерирует хук и инвалидирует кэш,
+    # перезагрузка очищает /tmp. При попадании в кэш хук сразу применяет
+    # блобы — окно «NDM снёс цепочки, правил нет» сокращается до
+    # длительности самих iptables-restore.
+    _xkeen_cache_dir="/tmp/xkeen_rules_cache"
+
+    _xkeen_ensure_ipsets() {
+        command -v ipset >/dev/null 2>&1 || return 0
+        if [ "$iptables_supported" = "true" ]; then
+            ipset create ext_exclude hash:ip family inet -exist 2>/dev/null
+            ipset create user_exclude hash:net family inet -exist 2>/dev/null
+            ipset create geo_exclude hash:net family inet -exist 2>/dev/null
+            ipset create geo_override hash:net family inet -exist 2>/dev/null
+        fi
+        if [ "$ip6tables_supported" = "true" ]; then
+            ipset create ext_exclude6 hash:ip family inet6 -exist 2>/dev/null
+            ipset create user_exclude6 hash:net family inet6 -exist 2>/dev/null
+            ipset create geo_exclude6 hash:net family inet6 -exist 2>/dev/null
+            ipset create geo_override6 hash:net family inet6 -exist 2>/dev/null
+        fi
+    }
+
+    _xkeen_cache_valid() {
+        [ -s "$_xkeen_cache_dir/key" ] || return 1
+        [ "$(cat "$_xkeen_cache_dir/key" 2>/dev/null)" = "$(md5sum "$0" 2>/dev/null | awk '{print $1}')" ]
+    }
+
+    # Восстанавливает хвостовой перевод строки, съеденный $(cat ...):
+    # _xkeen_apply_table печатает блоб через printf '%s' и рассчитывает,
+    # что каждая строка правил завершена.
+    _xkeen_cache_load() {
+        for _cn in v4_nat v4_mangle v6_nat v6_mangle; do
+            _cb=$(cat "$_xkeen_cache_dir/$_cn" 2>/dev/null)
+            [ -n "$_cb" ] && eval "_xkeen_${_cn}_rules=\"\$_cb
+\""
+        done
+    }
+
+    _xkeen_cache_save() {
+        rm -rf "${_xkeen_cache_dir}.new" 2>/dev/null
+        mkdir -p "${_xkeen_cache_dir}.new" 2>/dev/null || return 0
+        printf '%s' "$_xkeen_v4_nat_rules"    > "${_xkeen_cache_dir}.new/v4_nat"
+        printf '%s' "$_xkeen_v4_mangle_rules" > "${_xkeen_cache_dir}.new/v4_mangle"
+        printf '%s' "$_xkeen_v6_nat_rules"    > "${_xkeen_cache_dir}.new/v6_nat"
+        printf '%s' "$_xkeen_v6_mangle_rules" > "${_xkeen_cache_dir}.new/v6_mangle"
+        md5sum "$0" 2>/dev/null | awk '{print $1}' > "${_xkeen_cache_dir}.new/key"
+        rm -rf "$_xkeen_cache_dir" 2>/dev/null
+        mv "${_xkeen_cache_dir}.new" "$_xkeen_cache_dir" 2>/dev/null
+    }
+
+    if _xkeen_cache_valid; then
+        _xkeen_ensure_ipsets
+        _xkeen_cache_load
+        [ "$iptables_supported" = "true" ] && configure_route 4
+        [ "$ip6tables_supported" = "true" ] && configure_route 6
+        _xkeen_apply
+        _xkeen_sync_deny_mac_ipset
+        exit 0
+    fi
+
     if [ -n "$port_donor" ] || [ -n "$port_exclude" ]; then
         [ "$file_dns" = "true" ] && [ "$proxy_dns" = "on" ] && [ -n "$port_donor" ] && port_donor="53,$port_donor"
     fi
@@ -2675,6 +2739,10 @@ USER_POLICIES_EOF
     # Атомарно применяем все аккумулированные правила одним
     # iptables-restore --noflush per (family, table).
     _xkeen_apply
+
+    # Блобы детерминированы конфигурацией — сохраняем для быстрых
+    # последующих прогонов (см. _xkeen_cache_* выше).
+    _xkeen_cache_save
 
     # Медленная часть (curl к hotspot API) — строго после восстановления
     # правил: см. комментарий у _xkeen_sync_deny_mac_ipset.


### PR DESCRIPTION
## Проблема

Набор правил, который строит netfilter-хук, полностью детерминирован: все входные данные (порты, марки, политики, exclude-списки) запечены в сам сгенерированный файл. Тем не менее каждый прогон хука собирает блобы заново — это сотни вызовов shell-функций и конкатенаций строк, и именно эта фаза доминирует во времени между моментом, когда NDM сносит цепочки xkeen при пересборке файрвола (на провайдерах с коротким DHCP lease — каждые ~150 секунд), и моментом, когда хук их восстанавливает. На MIPS/ARM-процессорах роутеров это сотни миллисекунд чистого шелл-оверхеда, в течение которых проксируемый трафик идёт мимо политики с реальным IP.

## Что меняется

- После успешной полной сборки четыре restore-блоба (family × table) сохраняются в `/tmp/xkeen_rules_cache` с ключом = md5 самого файла хука.
- На следующем прогоне при совпадении ключа хук пропускает всю фазу сборки: создаёт нужные ipset'ы (`-exist`), загружает блобы из кэша и сразу применяет их через `iptables-restore --noflush`.
- Инвалидация встроена в саму схему и не требует отдельной логики:
  - любое изменение конфигурации перегенерирует хук → меняется его md5 → кэш промахивается и пересобирается;
  - `/tmp` не переживает перезагрузку → первый прогон после ребута всегда полный.
- Delete-list устаревших правил по-прежнему строится на каждом прогоне по живому `iptables-save` — кэшируется только детерминированная часть.

## Преимущества

- Окно «цепочки снесены — правил нет», в которое трафик утекает в обход прокси, сокращается практически до длительности самих вызовов `iptables-restore`. В связке с intact-fast-path это доводит до конца оптимизацию, начатую в #98.
- Меньше CPU на каждое событие netfilter — заметно на слабых устройствах и на частых событиях (короткие DHCP lease, расписания).
- Схема безопасна по построению: кэш-мисс в любой непонятной ситуации означает обычную полную пересборку, т.е. текущее поведение.

Проверено `sh -n` на сгенерированном хуке (TProxy-конфигурация). Готов прогнать замеры «до/после» на живом устройстве с коротким lease и приложить цифры.
