### PR TITLE
fix: брать код возврата curl, а не awk, в curl_with_timeout

### DIFF
--- a/scripts/_xkeen/01_info/01_info_variable.sh
+++ b/scripts/_xkeen/01_info/01_info_variable.sh
@@ -166,14 +166,18 @@ curl_with_timeout() {
 
     if [ "$_is_probe" = "0" ]; then
         # Режим скачивания (fetch_with_mirrors)
+        # Код возврата curl снимаем через отдельный дескриптор: $? после пайпа
+        # вернул бы код awk из indent_stderr_live, а не curl, из-за чего любой
+        # сетевой сбой выглядел бы как успех. pipefail в POSIX sh недоступен.
+        exec 3>&1
         if [ -e "/tmp/toff" ]; then
-            (curl -# --connect-timeout 10 "$@" 2>&1 1>&3 | indent_stderr_live) 3>&1
+            _curl_rc=$( { { curl -# --connect-timeout 10 "$@" 2>&1 1>&3; echo $? >&4; } | indent_stderr_live; } 4>&1 )
         else
-            (curl -# --connect-timeout 10 -m 180 "$@" 2>&1 1>&3 | indent_stderr_live) 3>&1
+            _curl_rc=$( { { curl -# --connect-timeout 10 -m 180 "$@" 2>&1 1>&3; echo $? >&4; } | indent_stderr_live; } 4>&1 )
         fi
-        _curl_rc=$?
+        exec 3>&-
 
-        return $_curl_rc
+        return "${_curl_rc:-1}"
     else
         # Режим проверки доступности (probe_with_mirrors / test_github)
         if [ -e "/tmp/toff" ]; then


### PR DESCRIPTION
## Проблема

В режиме загрузки `curl_with_timeout` брал `$?` после пайпа — то есть код возврата `awk` из `indent_stderr_live`, а не `curl`:

```sh
(curl -# --connect-timeout 10 -m 180 "$@" 2>&1 1>&3 | indent_stderr_live) 3>&1
_curl_rc=$?
```

`awk` форматирует прогресс-бар и завершается успешно всегда, поэтому функция возвращала `0` при любом сетевом сбое. `set -o pipefail` в POSIX sh недоступен, и в проекте его нет нигде.

## Следствие

В `fetch_with_mirrors` (`00_fetch_with_mirrors.sh:122`) проверка

```sh
if curl_with_timeout -fL -o "$_fwm_tmp" "$_fwm_fetch"; then
    ...
else
    _last_error="curl_failed"
fi
```

всегда истинна, а ветка `else` недостижима. Отличить сетевой отказ от испорченного содержимого невозможно: причина сбоя выставляется только валидатором, поэтому обрыв связи попадает в `xkeen -diag` как проблема с содержимым файла.

## Решение

Код возврата `curl` снимается через отдельный дескриптор. Прежнее поведение сохранено полностью: stdout проходит насквозь через fd 3, stderr по-прежнему форматируется `indent_stderr_live`.

Возврат обёрнут в `${_curl_rc:-1}` — на случай, если подстановка вернёт пустую строку, чтобы `return` не получил пустой аргумент.

## Проверка

| Проверка | Результат |
| --- | --- |
| `dash` и `sh`, коды 0 / 22 / 28 | Пробрасываются верно, stdout не повреждён |
| Реальный `curl`, **до** фикса | `rc=0` на недоступном хосте и на ошибке HTTP |
| Реальный `curl`, **после** фикса | `rc=6` и `rc=56`; успешная загрузка по-прежнему `rc=0` |
| `shellcheck -s sh` | Набор диагностик идентичен до и после — новых warning нет |

Сравнение на одних и тех же URL:

```
=== ДО ФИКСА ===
    rc=0  <- https://this-host-does-not-exist-xk.invalid/f
    rc=0  <- https://github.com/jameszeroX/XKeen/raw/main/NOPE-404

=== ПОСЛЕ ФИКСА ===
    rc=6  <- https://this-host-does-not-exist-xk.invalid/f
    rc=56 <- https://github.com/jameszeroX/XKeen/raw/main/NOPE-404
```

Отдельно проверено, что fd 3 в проекте больше нигде не используется, поэтому `exec 3>&-` ничего не ломает.

Изменение затрагивает один файл, +8 / −4. Поведения в успешном сценарии не меняет.
