### PR TITLE
fix(balancer): не зацикливать меню -sb без TTY

### DIFF
--- a/scripts/_xkeen/04_tools/08_tools_balancer/02_balancer_control.sh
+++ b/scripts/_xkeen/04_tools/08_tools_balancer/02_balancer_control.sh
@@ -190,7 +190,10 @@ sb_menu() {
         printf '     2. Прогнать замер сейчас\n'
         printf '     0. Выход\n\n'
         printf '  Ваш выбор: '
-        read -r choice
+        # read возвращает ненулевой код на EOF (нет TTY: пайп, ssh без -t, cron).
+        # Без этой проверки пустой ввод уходил бы в ветку * и while true крутился
+        # бы вплотную — CPU-spin. EOF трактуем как выход из меню.
+        read -r choice || { echo; return 0; }
         case "$choice" in
             0) return 0 ;;
             1)


### PR DESCRIPTION
Мелкий фикс в модуле балансировки (`xkeen -sb`).

## Проблема

`sb_menu` (`02_balancer_control.sh`) читает выбор через `read -r choice` без проверки кода возврата. На EOF — когда терминала нет (пайп, `ssh router 'xkeen -sb'` без `-t`, запуск из cron/обёртки) — `read` сразу возвращает ненулевой код, `choice` остаётся пустым, управление уходит в ветку `*` («Неверный ввод»), и `while true` крутится вплотную: **CPU-spin / бесконечный вывод меню**.

## Починка

```sh
read -r choice || { echo; return 0; }
```

EOF трактуется как выход из меню — так же, как это делает остальной ask-слой (ср. `sb_ensure_api`, который на EOF корректно уходит в `return 1`). Одна строка + комментарий.

## Проверка

- `sh -n` на BusyBox `ash` — чисто.
- Симуляция цикла: без TTY (`</dev/null`) меню выходит на первой итерации вместо спина; ввод `0` и «мусор→EOF» тоже завершаются корректно.
- `spec/test_balancer.sh` — 25/25 без регресса.