### PR TITLE
fix: escape single quotes in netfilter hook vars via POSIX sed

### DIFF
--- a/scripts/_xkeen/02_install/07_install_register/04_register_init.sh
+++ b/scripts/_xkeen/02_install/07_install_register/04_register_init.sh
@@ -2006,7 +2006,9 @@ EOL
         local name="$1"
         local val="$2"
         local safe_val
-        safe_val="${val//\'/\'\\\'\'}"
+        # POSIX: BusyBox ash не поддерживает ${var//pattern/repl} (bashism).
+        # Экранируем одинарные кавычки для записи name='...' в hook.
+        safe_val=$(printf '%s' "$val" | sed "s/'/'\\\\''/g")
         printf "%s='%s'\n" "$name" "$safe_val" >> "$file_netfilter_hook"
     }
 


### PR DESCRIPTION
## Что и зачем
BusyBox ash не поддерживает bashism `${var//pattern/repl}`, которым экранировались одинарные кавычки при записи строк `name='...'` в генерируемый netfilter-хук. Заменил на POSIX `sed`. Без этого значение с кавычкой ломало хук.

## Как проверял
На роутере Keenetic с ядром mihomo (TProxy): хук генерируется корректно; `sh -n` на busybox.

**Часть 1/8** — мержить первой.

---
Часть стека харденинга. Полный порядок влития: **1 inject_var → 2 RCI/dry-run → 3 установка → 4 mihomo-geo → 5 GOMEMLIMIT → 6 WAN-skip → 7 hook-renew → 8 serialize**. Ветка включает коммиты предыдущих частей — diff очистится после их мержа.
