### PR TITLE
fix: don't rewrite router HTTP port on RCI failure

### DIFF
--- a/scripts/_xkeen/02_install/07_install_register/04_register_init.sh
+++ b/scripts/_xkeen/02_install/07_install_register/04_register_init.sh
@@ -340,6 +340,9 @@ refresh_port_cache() { api_port_json=$(curl_api "${url_server}/${url_keenetic_po
 json_get_ports() { [ -n "$api_port_json" ] && printf '%s' "$api_port_json" | jq -r '.port, (.ssl.port // empty)' 2>/dev/null; }
 
 # Получение портов Keenetic
+# Важно: при сбое RCI НЕ меняем конфигурацию HTTP-портов роутера.
+# Старый fallback (ndmc ip http port 8080/80 + save) молча ломал
+# кастомные порты веб-интерфейса у пользователей.
 get_keenetic_port() {
     ports=""
     ports=$(json_get_ports)
@@ -349,15 +352,10 @@ get_keenetic_port() {
     esac
 
     if [ -z "$ports" ]; then
-        ndmc -c 'ip http port 8080' >/dev/null 2>&1
-        ndmc -c 'ip http port 80' >/dev/null 2>&1
-        ndmc -c 'system configuration save' >/dev/null 2>&1
-        sleep 2
-        refresh_port_cache
-        ports=$(json_get_ports)
+        log_warning_router "Не удалось получить порты HTTP Keenetic через RCI; проверка 443 пропущена"
+        echo ""
+        return 0
     fi
-
-    [ -n "$ports" ] || return 1
 
     echo "$ports"
     return 0

--- a/scripts/_xkeen/02_install/07_install_register/04_register_init.sh
+++ b/scripts/_xkeen/02_install/07_install_register/04_register_init.sh
@@ -2006,7 +2006,9 @@ EOL
         local name="$1"
         local val="$2"
         local safe_val
-        safe_val="${val//\'/\'\\\'\'}"
+        # POSIX: BusyBox ash не поддерживает ${var//pattern/repl} (bashism).
+        # Экранируем одинарные кавычки для записи name='...' в hook.
+        safe_val=$(printf '%s' "$val" | sed "s/'/'\\\\''/g")
         printf "%s='%s'\n" "$name" "$safe_val" >> "$file_netfilter_hook"
     }
 


### PR DESCRIPTION
get_keenetic_port previously ran `ndmc ip http port 8080/80 + save` when RCI was unreachable, silently breaking users' custom web-UI ports. Now it only warns and skips the 443 check.

_(Ранее этот PR также добавлял dry-run проверки конфига ядра перед start/restart. Убрано: `mihomo -t` на этом железе занимает ~53 с и зависит от WAN — во время провайдерского обрыва он ложно валит restart. Разбор инцидента 2026-07-29.)_