### PR TITLE
fix: atomic XKeen unpack and archive integrity checks

### DIFF
--- a/scripts/_xkeen/02_install/02_install_mihomo.sh
+++ b/scripts/_xkeen/02_install/02_install_mihomo.sh
@@ -20,6 +20,17 @@ install_mihomo() {
 
     _mihomo_tmp="$mtmp_dir/mihomo.tmp.$$"
     gzip_err="$mtmp_dir/gzip.err.$$"
+    # Предварительная проверка целостности gzip до записи на диск
+    if ! gzip -t "$mihomo_archive" 2>"$gzip_err"; then
+        _err="$(cat "$gzip_err" 2>/dev/null)"
+        rm -f "$gzip_err" "$mihomo_archive"
+        echo -e "  ${red}Ошибка${reset}: Архив Mihomo повреждён (gzip -t)"
+        [ -n "$_err" ] && echo -e "  Подробности: $_err"
+        [ -f "$install_dir/mihomo_bak" ] && mv "$install_dir/mihomo_bak" "$install_dir/mihomo" && \
+            echo -e "  ${yellow}Восстановлен${reset} предыдущий бинарник Mihomo"
+        return 1
+    fi
+    rm -f "$gzip_err"
     if gzip -cd "$mihomo_archive" > "$_mihomo_tmp" 2>"$gzip_err" && [ -s "$_mihomo_tmp" ]; then
         rm -f "$gzip_err"
     else

--- a/scripts/_xkeen/02_install/03_install_xkeen.sh
+++ b/scripts/_xkeen/02_install/03_install_xkeen.sh
@@ -11,21 +11,33 @@ install_xkeen() {
             return 1
         fi
 
-        # Распаковка архива
-        tar -xzf "$xkeen_archive" -C "$install_dir" xkeen _xkeen
-
-        # Проверка наличия _xkeen в install_dir и его перемещение
-        if [ -d "$install_dir/_xkeen" ]; then
-            rm -rf "$install_dir/.xkeen"
-            mv "$install_dir/_xkeen" "$install_dir/.xkeen"
-        else
-            echo -e "  ${red}Ошибка${reset}: _xkeen не была правильно перенесена"
+        # Распаковка во временный каталог, затем атомарная замена —
+        # при обрыве не оставляем полузаписанный .xkeen поверх живой установки.
+        _xk_extract="${tmp_ram}/xkeen_extract.$$"
+        rm -rf "$_xk_extract"
+        mkdir -p "$_xk_extract" || {
+            echo -e "  ${red}Ошибка${reset}: Не удалось создать временный каталог для распаковки"
             rm -f "$xkeen_archive"
+            return 1
+        }
+
+        if ! tar -xzf "$xkeen_archive" -C "$_xk_extract" xkeen _xkeen; then
+            echo -e "  ${red}Ошибка${reset}: Не удалось распаковать архив XKeen"
+            rm -rf "$_xk_extract" "$xkeen_archive"
             return 1
         fi
 
-        # Удаление архива
-        rm "$xkeen_archive"
+        if [ ! -f "$_xk_extract/xkeen" ] || [ ! -d "$_xk_extract/_xkeen" ]; then
+            echo -e "  ${red}Ошибка${reset}: В архиве XKeen нет ожидаемых xkeen/_xkeen"
+            rm -rf "$_xk_extract" "$xkeen_archive"
+            return 1
+        fi
+
+        chmod +x "$_xk_extract/xkeen"
+        mv -f "$_xk_extract/xkeen" "$install_dir/xkeen"
+        rm -rf "$install_dir/.xkeen"
+        mv "$_xk_extract/_xkeen" "$install_dir/.xkeen"
+        rm -rf "$_xk_extract" "$xkeen_archive"
     fi
     [ -d "$log_dir/xkeen" ] && rm -rf "$log_dir/xkeen"
     return 0

--- a/scripts/_xkeen/04_tools/07_tools_downloaders/00_fetch_with_mirrors.sh
+++ b/scripts/_xkeen/04_tools/07_tools_downloaders/00_fetch_with_mirrors.sh
@@ -295,7 +295,7 @@ _network_probe() {
 }
 
 # Универсальный загрузчик файлов с повторными попытками
-# Аргументы: $1 - URL, $2 - Путь сохранения, $3 - Имя компонента, $4 - max_attempts, $5 - delay
+# Аргументы: $1 - URL, $2 - Путь сохранения, $3 - Имя компонента, $4 - max_attempts, $5 - delay, $6 - min_size (опц.)
 # Возвращает: 0 - успешно, 1 - ошибка
 _network_download() {
     url="$1"
@@ -303,6 +303,7 @@ _network_download() {
     component="$3"
     max_attempts="${4:-1}"
     delay="${5:-2}"
+    min_size="${6:-24576}"
     
     attempt=1
     success=1
@@ -312,7 +313,7 @@ _network_download() {
             printf "  Загрузка %s (Попытка %d из %d)...\n" "$component" "$attempt" "$max_attempts"
         fi
 
-        if fetch_with_mirrors "$url" "$target" 24576; then
+        if fetch_with_mirrors "$url" "$target" "$min_size"; then
             success=0
             break
         fi

--- a/scripts/_xkeen/04_tools/07_tools_downloaders/01_downloaders_mihomo.sh
+++ b/scripts/_xkeen/04_tools/07_tools_downloaders/01_downloaders_mihomo.sh
@@ -112,7 +112,7 @@ download_mihomo() {
 
         printf "  ${yellow}Выполняется загрузка${reset} Mihomo %s\n" "$version_selected"
 
-        if ! _network_download "$download_url" "$tmp_ram/mihomo.$extension" "Mihomo" "$max_attempts" "$delay"; then
+        if ! _network_download "$download_url" "$tmp_ram/mihomo.$extension" "Mihomo" "$max_attempts" "$delay" 1048576; then
             continue
         fi
 

--- a/scripts/_xkeen/04_tools/07_tools_downloaders/01_downloaders_xray.sh
+++ b/scripts/_xkeen/04_tools/07_tools_downloaders/01_downloaders_xray.sh
@@ -31,7 +31,7 @@ _xray_perform_install() {
     fi
 
     printf "  ${yellow}Выполняется загрузка${reset} Xray %s\n" "$version"
-    if ! _network_download "$download_url" "$tmp_ram/xray.$extension" "Xray" "$max_attempts" "$delay"; then
+    if ! _network_download "$download_url" "$tmp_ram/xray.$extension" "Xray" "$max_attempts" "$delay" 1048576; then
         return 1
     fi
 


### PR DESCRIPTION
## Что и зачем
- Распаковка XKeen во временный каталог с проверкой и атомарной подменой — обрыв обновления не оставит полуустановку.
- `gzip -t` для архива mihomo до записи на диск, с откатом на предыдущий бинарник при повреждении.
- Минимальный размер загрузки ядра — отсечь обрезанные файлы/HTML-заглушки.

## Как проверял
На роутере Keenetic (mihomo/TProxy): установка/обновление проходят, прерывание не бьёт живую установку; `sh -n`.

**Часть 3/8** — после части 2.

---
Часть стека харденинга. Полный порядок влития: **1 inject_var → 2 RCI/dry-run → 3 установка → 4 mihomo-geo → 5 GOMEMLIMIT → 6 WAN-skip → 7 hook-renew → 8 serialize**. Ветка включает коммиты предыдущих частей — diff очистится после их мержа.
