### PR TITLE
perf: skip netfilter hook work when WAN IP is unchanged

### DIFF
--- a/scripts/_xkeen/02_install/02_install_mihomo.sh
+++ b/scripts/_xkeen/02_install/02_install_mihomo.sh
@@ -20,6 +20,17 @@ install_mihomo() {
 
     _mihomo_tmp="$mtmp_dir/mihomo.tmp.$$"
     gzip_err="$mtmp_dir/gzip.err.$$"
+    # Предварительная проверка целостности gzip до записи на диск
+    if ! gzip -t "$mihomo_archive" 2>"$gzip_err"; then
+        _err="$(cat "$gzip_err" 2>/dev/null)"
+        rm -f "$gzip_err" "$mihomo_archive"
+        echo -e "  ${red}Ошибка${reset}: Архив Mihomo повреждён (gzip -t)"
+        [ -n "$_err" ] && echo -e "  Подробности: $_err"
+        [ -f "$install_dir/mihomo_bak" ] && mv "$install_dir/mihomo_bak" "$install_dir/mihomo" && \
+            echo -e "  ${yellow}Восстановлен${reset} предыдущий бинарник Mihomo"
+        return 1
+    fi
+    rm -f "$gzip_err"
     if gzip -cd "$mihomo_archive" > "$_mihomo_tmp" 2>"$gzip_err" && [ -s "$_mihomo_tmp" ]; then
         rm -f "$gzip_err"
     else

--- a/scripts/_xkeen/02_install/03_install_xkeen.sh
+++ b/scripts/_xkeen/02_install/03_install_xkeen.sh
@@ -11,21 +11,33 @@ install_xkeen() {
             return 1
         fi
 
-        # Распаковка архива
-        tar -xzf "$xkeen_archive" -C "$install_dir" xkeen _xkeen
-
-        # Проверка наличия _xkeen в install_dir и его перемещение
-        if [ -d "$install_dir/_xkeen" ]; then
-            rm -rf "$install_dir/.xkeen"
-            mv "$install_dir/_xkeen" "$install_dir/.xkeen"
-        else
-            echo -e "  ${red}Ошибка${reset}: _xkeen не была правильно перенесена"
+        # Распаковка во временный каталог, затем атомарная замена —
+        # при обрыве не оставляем полузаписанный .xkeen поверх живой установки.
+        _xk_extract="${tmp_ram}/xkeen_extract.$$"
+        rm -rf "$_xk_extract"
+        mkdir -p "$_xk_extract" || {
+            echo -e "  ${red}Ошибка${reset}: Не удалось создать временный каталог для распаковки"
             rm -f "$xkeen_archive"
+            return 1
+        }
+
+        if ! tar -xzf "$xkeen_archive" -C "$_xk_extract" xkeen _xkeen; then
+            echo -e "  ${red}Ошибка${reset}: Не удалось распаковать архив XKeen"
+            rm -rf "$_xk_extract" "$xkeen_archive"
             return 1
         fi
 
-        # Удаление архива
-        rm "$xkeen_archive"
+        if [ ! -f "$_xk_extract/xkeen" ] || [ ! -d "$_xk_extract/_xkeen" ]; then
+            echo -e "  ${red}Ошибка${reset}: В архиве XKeen нет ожидаемых xkeen/_xkeen"
+            rm -rf "$_xk_extract" "$xkeen_archive"
+            return 1
+        fi
+
+        chmod +x "$_xk_extract/xkeen"
+        mv -f "$_xk_extract/xkeen" "$install_dir/xkeen"
+        rm -rf "$install_dir/.xkeen"
+        mv "$_xk_extract/_xkeen" "$install_dir/.xkeen"
+        rm -rf "$_xk_extract" "$xkeen_archive"
     fi
     [ -d "$log_dir/xkeen" ] && rm -rf "$log_dir/xkeen"
     return 0

--- a/scripts/_xkeen/02_install/07_install_register/01_register_mihomo.sh
+++ b/scripts/_xkeen/02_install/07_install_register/01_register_mihomo.sh
@@ -60,6 +60,10 @@ add_mihomo_config() {
             cat << EOF > "$mihomo_conf_dir/config.yaml"
 tproxy-port: 1181
 redir-port: 1182
+# Автообновление GeoSite/GeoIP/ASN (XKeen -ug этими файлами не управляет)
+geo-auto-update: true
+geo-update-interval: 24
+# Не открывайте external-controller в LAN без secret — это полный контроль над ядром
 # Руководство по конфигурации Mihomo - https://wiki.metacubex.one/ru/config/
 EOF
 

--- a/scripts/_xkeen/02_install/07_install_register/04_register_init.sh
+++ b/scripts/_xkeen/02_install/07_install_register/04_register_init.sh
@@ -171,6 +171,51 @@ get_rci_token() {
 }
 get_rci_token
 
+# GOMEMLIMIT для mihomo: доля RAM или абсолютный лимит из xkeen.json.
+# Дефолт — 50% RAM (сохраняет прежнее поведение). Внешний
+# GOMEMLIMIT в окружении всегда побеждает.
+load_gomemlimit_settings() {
+    gomemlimit_percent=50
+    gomemlimit_mb=""
+
+    [ ! -f "$xkeen_config" ] && return 0
+    command -v jq >/dev/null 2>&1 || return 0
+
+    _gml_json=$(strip_json_comments "$xkeen_config")
+    _gml_v=$(printf '%s' "$_gml_json" | jq -r '.xkeen.gomemlimit_percent // empty' 2>/dev/null)
+    if [ -n "$_gml_v" ] && [ "$_gml_v" -ge 1 ] 2>/dev/null && [ "$_gml_v" -le 90 ] 2>/dev/null; then
+        gomemlimit_percent="$_gml_v"
+    fi
+    _gml_v=$(printf '%s' "$_gml_json" | jq -r '.xkeen.gomemlimit_mb // empty' 2>/dev/null)
+    if [ -n "$_gml_v" ] && [ "$_gml_v" -ge 64 ] 2>/dev/null; then
+        gomemlimit_mb="$_gml_v"
+    fi
+    unset _gml_json _gml_v
+}
+
+# Выставляет GOMEMLIMIT и gomemlimit_value (для inject в netfilter-хук).
+apply_gomemlimit() {
+    [ -n "$GOMEMLIMIT" ] && { gomemlimit_value="$GOMEMLIMIT"; return 0; }
+
+    load_gomemlimit_settings
+    gomemlimit_value=""
+
+    if [ -n "$gomemlimit_mb" ]; then
+        gomemlimit_value="${gomemlimit_mb}MiB"
+        export GOMEMLIMIT="$gomemlimit_value"
+        return 0
+    fi
+
+    _mem_kb=$(awk '/^MemTotal:/{print $2}' /proc/meminfo 2>/dev/null)
+    if [ -n "$_mem_kb" ] && [ "$_mem_kb" -gt 0 ] 2>/dev/null; then
+        _goml=$(( _mem_kb * gomemlimit_percent / 100 / 1024 ))
+        [ "$_goml" -lt 64 ] && _goml=64
+        gomemlimit_value="${_goml}MiB"
+        export GOMEMLIMIT="$gomemlimit_value"
+    fi
+    unset _mem_kb _goml
+}
+
 wait_for_webui() {
     max_wait=20
     i=0
@@ -2064,6 +2109,9 @@ EOL
     inject_var url_server "$url_server"
     inject_var url_hotspot "$url_hotspot"
     inject_var rci_token "$rci_token"
+    # GOMEMLIMIT для respawn mihomo внутри хука (вычислен при генерации)
+    apply_gomemlimit
+    inject_var gomemlimit_value "$gomemlimit_value"
 
     cat >> "$file_netfilter_hook" <<'EOL'
 
@@ -2915,18 +2963,11 @@ else
         ;;
         mihomo)
             export CLASH_HOME_DIR="$directory_configs_app"
-            # mihomo — Go-приложение: без GOMEMLIMIT сборщик мусора не
-            # стремится возвращать память ОС, и на роутерах RSS ползёт
-            # вверх до OOM. Мягкий лимит в половину RAM (минимум 64MiB)
-            # заставляет GC ужиматься заранее. Уже заданный извне
-            # GOMEMLIMIT не игнорируется.
-            if [ -z "$GOMEMLIMIT" ]; then
-                _mem_kb=$(awk '/^MemTotal:/{print $2}' /proc/meminfo 2>/dev/null)
-                if [ -n "$_mem_kb" ] && [ "$_mem_kb" -gt 0 ] 2>/dev/null; then
-                    _goml=$(( _mem_kb / 2048 ))
-                    [ "$_goml" -lt 64 ] && _goml=64
-                    export GOMEMLIMIT="${_goml}MiB"
-                fi
+            # Мягкий лимит памяти для Go GC. Значение запекается при
+            # configure_firewall из xkeen.json (gomemlimit_percent /
+            # gomemlimit_mb) или внешнего GOMEMLIMIT.
+            if [ -z "$GOMEMLIMIT" ] && [ -n "$gomemlimit_value" ]; then
+                export GOMEMLIMIT="$gomemlimit_value"
             fi
             "$name_client" >/dev/null 2>&1 &
         ;;
@@ -3340,17 +3381,9 @@ proxy_start() {
                     ;;
                     mihomo)
                         export CLASH_HOME_DIR="$directory_configs_app"
-                        # См. комментарий у запуска mihomo в netfilter-хуке:
-                        # мягкий лимит памяти для Go GC, половина RAM,
+                        # См. apply_gomemlimit: доля/лимит из xkeen.json,
                         # минимум 64MiB, внешний GOMEMLIMIT не игнорируется.
-                        if [ -z "$GOMEMLIMIT" ]; then
-                            _mem_kb=$(awk '/^MemTotal:/{print $2}' /proc/meminfo 2>/dev/null)
-                            if [ -n "$_mem_kb" ] && [ "$_mem_kb" -gt 0 ] 2>/dev/null; then
-                                _goml=$(( _mem_kb / 2048 ))
-                                [ "$_goml" -lt 64 ] && _goml=64
-                                export GOMEMLIMIT="${_goml}MiB"
-                            fi
-                        fi
+                        apply_gomemlimit
                         if [ -n "$fd_out" ]; then
                             nohup "$name_client" >/dev/null 2>&1 &
                             unset fd_out

--- a/scripts/_xkeen/02_install/07_install_register/04_register_init.sh
+++ b/scripts/_xkeen/02_install/07_install_register/04_register_init.sh
@@ -2824,10 +2824,26 @@ USER_POLICIES_EOF
         return 0
     }
 
+    # Текущий WAN IPv4 (тот же способ, что get_exclude_ip4 при генерации).
+    # На коротком DHCP lease (MGTS ~300 с) renew приходит каждые ~150 с
+    # с тем же IP: NDM всё равно зовёт netfilter.d. Если IP не сменился
+    # и цепочки на месте — не трогаем даже configure_route (он и так
+    # идемпотентен, но лишние ip route show на каждом renew не нужны).
+    _xkeen_wan_state="/tmp/xkeen_wan_ip"
+    _xkeen_cur_wan=$(ip -o route get 195.208.4.1 2>/dev/null | sed -n 's/.*src \([^ ]*\).*/\1/p' || \
+                     ip -o route get 77.88.8.8 2>/dev/null | sed -n 's/.*src \([^ ]*\).*/\1/p')
+    _xkeen_prev_wan=$(cat "$_xkeen_wan_state" 2>/dev/null)
+
+    if [ -n "$_xkeen_cur_wan" ] && [ "$_xkeen_cur_wan" = "$_xkeen_prev_wan" ] && _xkeen_rules_intact; then
+        _xkeen_sync_deny_mac_ipset
+        exit 0
+    fi
+
     if _xkeen_rules_intact; then
         [ "$iptables_supported" = "true" ] && configure_route 4
         [ "$ip6tables_supported" = "true" ] && configure_route 6
         _xkeen_sync_deny_mac_ipset
+        [ -n "$_xkeen_cur_wan" ] && printf '%s' "$_xkeen_cur_wan" > "$_xkeen_wan_state"
         exit 0
     fi
 
@@ -2892,6 +2908,7 @@ USER_POLICIES_EOF
         [ "$ip6tables_supported" = "true" ] && configure_route 6
         _xkeen_apply
         _xkeen_sync_deny_mac_ipset
+        [ -n "$_xkeen_cur_wan" ] && printf '%s' "$_xkeen_cur_wan" > "$_xkeen_wan_state"
         exit 0
     fi
 
@@ -2946,6 +2963,7 @@ USER_POLICIES_EOF
     # Медленная часть (curl к hotspot API) — строго после восстановления
     # правил: см. комментарий у _xkeen_sync_deny_mac_ipset.
     _xkeen_sync_deny_mac_ipset
+    [ -n "$_xkeen_cur_wan" ] && printf '%s' "$_xkeen_cur_wan" > "$_xkeen_wan_state"
 else
     [ -f "/tmp/xkeen_starting.lock" ] && exit 0
     touch "/tmp/xkeen_starting.lock"

--- a/scripts/_xkeen/04_tools/07_tools_downloaders/00_fetch_with_mirrors.sh
+++ b/scripts/_xkeen/04_tools/07_tools_downloaders/00_fetch_with_mirrors.sh
@@ -295,7 +295,7 @@ _network_probe() {
 }
 
 # Универсальный загрузчик файлов с повторными попытками
-# Аргументы: $1 - URL, $2 - Путь сохранения, $3 - Имя компонента, $4 - max_attempts, $5 - delay
+# Аргументы: $1 - URL, $2 - Путь сохранения, $3 - Имя компонента, $4 - max_attempts, $5 - delay, $6 - min_size (опц.)
 # Возвращает: 0 - успешно, 1 - ошибка
 _network_download() {
     url="$1"
@@ -303,6 +303,7 @@ _network_download() {
     component="$3"
     max_attempts="${4:-1}"
     delay="${5:-2}"
+    min_size="${6:-24576}"
     
     attempt=1
     success=1
@@ -312,7 +313,7 @@ _network_download() {
             printf "  Загрузка %s (Попытка %d из %d)...\n" "$component" "$attempt" "$max_attempts"
         fi
 
-        if fetch_with_mirrors "$url" "$target" 24576; then
+        if fetch_with_mirrors "$url" "$target" "$min_size"; then
             success=0
             break
         fi

--- a/scripts/_xkeen/04_tools/07_tools_downloaders/01_downloaders_mihomo.sh
+++ b/scripts/_xkeen/04_tools/07_tools_downloaders/01_downloaders_mihomo.sh
@@ -112,7 +112,7 @@ download_mihomo() {
 
         printf "  ${yellow}Выполняется загрузка${reset} Mihomo %s\n" "$version_selected"
 
-        if ! _network_download "$download_url" "$tmp_ram/mihomo.$extension" "Mihomo" "$max_attempts" "$delay"; then
+        if ! _network_download "$download_url" "$tmp_ram/mihomo.$extension" "Mihomo" "$max_attempts" "$delay" 1048576; then
             continue
         fi
 

--- a/scripts/_xkeen/04_tools/07_tools_downloaders/01_downloaders_xray.sh
+++ b/scripts/_xkeen/04_tools/07_tools_downloaders/01_downloaders_xray.sh
@@ -31,7 +31,7 @@ _xray_perform_install() {
     fi
 
     printf "  ${yellow}Выполняется загрузка${reset} Xray %s\n" "$version"
-    if ! _network_download "$download_url" "$tmp_ram/xray.$extension" "Xray" "$max_attempts" "$delay"; then
+    if ! _network_download "$download_url" "$tmp_ram/xray.$extension" "Xray" "$max_attempts" "$delay" 1048576; then
         return 1
     fi
 

--- a/scripts/xkeen
+++ b/scripts/xkeen
@@ -515,6 +515,31 @@ while [ $# -gt 0 ]; do
             smart_clear
             echo
             echo "  Обновление установленных баз GeoFile/GeoIPSET"
+
+            # Ядро из initd: для mihomo dat-файлы XKeen (/opt/etc/xray/dat)
+            # не используются — у mihomo свои GeoSite/geoip/ASN и geo-auto-update.
+            current_core=""
+            if [ -f "$initd_file" ]; then
+                current_core=$(grep -m1 '^name_client=' "$initd_file" 2>/dev/null | cut -d= -f2- | tr -d '"')
+            fi
+            if [ "$current_core" = "mihomo" ]; then
+                echo
+                echo -e "  Активное ядро: ${yellow}mihomo${reset}"
+                echo -e "  Базы GeoFile XKeen (xray/dat) этим ядром ${yellow}не используются${reset}"
+                echo -e "  Геоданные mihomo обновляет сам при ${yellow}geo-auto-update: true${reset} в config.yaml"
+                if [ -f "$mihomo_conf_dir/config.yaml" ] && [ -x "$install_dir/yq" ]; then
+                    _geo_auto=$("$install_dir/yq" '.geo-auto-update // false' "$mihomo_conf_dir/config.yaml" 2>/dev/null)
+                    if [ "$_geo_auto" != "true" ]; then
+                        echo -e "  ${yellow}Внимание${reset}: geo-auto-update выключен — базы mihomo могут устареть"
+                        echo -e "  Включите в config.yaml: ${yellow}geo-auto-update: true${reset}"
+                    else
+                        echo -e "  geo-auto-update: ${green}включён${reset} — mihomo обновит базы самостоятельно"
+                    fi
+                    unset _geo_auto
+                fi
+                echo -e "  Будут обновлены только списки ${yellow}GeoIPSET${reset} (исключения netfilter), если они установлены"
+            fi
+
             info_geosite
             info_geoip
             if 
@@ -527,18 +552,28 @@ while [ $# -gt 0 ]; do
                 [ -f "$ru_exclude_ipv4" ]; then
 
                 echo
+                # dat-файлы Xray на чистом mihomo-сетапе обычно пусты —
+                # install_* отработают no-op по флагам info_geosite/info_geoip.
                 install_geosite
                 install_geoip
                 update_user_geofiles
                 install_geoipset update
 
-                if pidof xray >/dev/null; then
+                if [ "$current_core" = "mihomo" ]; then
+                    if pidof mihomo >/dev/null; then
+                        # GeoIPSET загружается в ipset при старте — нужен reapply.
+                        "$initd_file" restart on >/dev/null 2>&1
+                    fi
+                elif pidof xray >/dev/null; then
                     "$initd_file" restart on >/dev/null 2>&1
                 fi
 
                 echo -e "  Обновление установленных баз GeoFile/GeoIPSET ${green}завершено${reset}"
             else
                 echo -e "  ${red}Не обнаружены${reset} базы GeoFile/GeoIPSET для обновления"
+                if [ "$current_core" = "mihomo" ]; then
+                    echo -e "  Для mihomo настройте ${yellow}geo-auto-update${reset} / ${yellow}geox-url${reset} в config.yaml"
+                fi
             fi
         ;;
 
@@ -838,19 +873,30 @@ while [ $# -gt 0 ]; do
 
         -ri)    # Пересоздать файл автозапуска XKeen
             smart_clear
-            "$initd_file" stop >/dev/null 2>&1
-            [ -e "$initd_file" ] && rm -f "$initd_file"
+            # Не останавливаем прокси и не rm initd заранее:
+            # register_xkeen_initd сам делает mv→бэкап и мигрирует
+            # name_client/порты/политики. Прежний rm убивал миграцию
+            # и сбрасывал mihomo-пользователей на дефолтный xray.
+            was_running=false
+            is_proxy_running && was_running=true
 
             echo -e "  Создание файла автозапуска ${yellow}XKeen${reset}"
             sleep 1
 
+            init_directories
             migrate_ports_from_initd
             register_xkeen_initd
             logs_register_xkeen_initd_info_console
+            add_chmod_init
 
             echo
             echo -e "  Создание файла автозапуска XKeen ${green}выполнено${reset}"
-            echo -e "  Если конфигурация настроена, то можете запустить проксирование командой '${yellow}xkeen -start${reset}'"
+            if [ "$was_running" = "true" ]; then
+                echo -e "  Прокси работал до пересоздания — выполняется ${yellow}перезапуск${reset}"
+                "$initd_file" restart on
+            else
+                echo -e "  Если конфигурация настроена, запустите проксирование командой '${yellow}xkeen -start${reset}'"
+            fi
         ;;
 
 


### PR DESCRIPTION
## Что и зачем
На коротких DHCP-lease NDM вызывает `netfilter.d` на каждый renew, обычно с тем же WAN IP. Запоминаем последний WAN IP и, если он не сменился и цепочки целы, пропускаем лишнюю работу по маршрутам/правилам.

## Как проверял
На роутере Keenetic (mihomo/TProxy) с частыми renew: цепочки остаются целыми, лишняя работа не выполняется; `sh -n`.

**Часть 6/8** — после части 5.

---
Часть стека харденинга. Полный порядок влития: **1 inject_var → 2 RCI/dry-run → 3 установка → 4 mihomo-geo → 5 GOMEMLIMIT → 6 WAN-skip → 7 hook-renew → 8 serialize**. Ветка включает коммиты предыдущих частей — diff очистится после их мержа.
