### PR TITLE
fix: atomic install paths, secret perms, safer cron rewrite

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -295,7 +295,11 @@ if ! download_xkeen_release "$url"; then
     exit 1
 fi
 
-if ! tar -xzf "$archive_name" -C /opt/sbin; then
+stage_dir="/opt/sbin/.xkeen-install.$$"
+rm -rf "$stage_dir"
+mkdir -p "$stage_dir"
+if ! tar -xzf "$archive_name" -C "$stage_dir" || [ ! -f "$stage_dir/xkeen" ] || [ ! -d "$stage_dir/_xkeen" ]; then
+    rm -rf "$stage_dir"
     rm -f "$archive_name"
     printf "  ${red}Ошибка${reset}: не удалось распаковать ${yellow}xkeen.tar.gz${reset}\n"
     exit 1
@@ -303,9 +307,20 @@ fi
 
 rm -f "$archive_name"
 
-if [ ! -x /opt/sbin/xkeen ]; then
+chmod +x "$stage_dir/xkeen"
+if ! mv "$stage_dir/xkeen" /opt/sbin/xkeen.new || ! mv /opt/sbin/xkeen.new /opt/sbin/xkeen; then
+    rm -rf "$stage_dir" /opt/sbin/xkeen.new
     printf "  ${red}Ошибка${reset}: после распаковки не найден исполняемый файл ${yellow}/opt/sbin/xkeen${reset}\n"
     exit 1
 fi
+rm -rf /opt/sbin/.xkeen.old
+[ -d /opt/sbin/.xkeen ] && mv /opt/sbin/.xkeen /opt/sbin/.xkeen.old
+if ! mv "$stage_dir/_xkeen" /opt/sbin/.xkeen; then
+    [ -d /opt/sbin/.xkeen.old ] && mv /opt/sbin/.xkeen.old /opt/sbin/.xkeen
+    rm -rf "$stage_dir"
+    printf "  ${red}Ошибка${reset}: не удалось установить модули XKeen\n"
+    exit 1
+fi
+rm -rf /opt/sbin/.xkeen.old "$stage_dir"
 
 exec /opt/sbin/xkeen -i

--- a/scripts/_xkeen/02_install/03_install_xkeen.sh
+++ b/scripts/_xkeen/02_install/03_install_xkeen.sh
@@ -11,33 +11,33 @@ install_xkeen() {
             return 1
         fi
 
-        # Распаковка во временный каталог, затем атомарная замена —
-        # при обрыве не оставляем полузаписанный .xkeen поверх живой установки.
-        _xk_extract="${tmp_ram}/xkeen_extract.$$"
-        rm -rf "$_xk_extract"
-        mkdir -p "$_xk_extract" || {
+        # Unpack away from the live tree, verify, then replace directories
+        # using the .old dance so interruption retains a usable installation.
+        stage_dir="$install_dir/.xkeen.stage.$$"
+        rm -rf "$stage_dir"
+        mkdir -p "$stage_dir" || {
             echo -e "  ${red}Ошибка${reset}: Не удалось создать временный каталог для распаковки"
             rm -f "$xkeen_archive"
             return 1
         }
-
-        if ! tar -xzf "$xkeen_archive" -C "$_xk_extract" xkeen _xkeen; then
-            echo -e "  ${red}Ошибка${reset}: Не удалось распаковать архив XKeen"
-            rm -rf "$_xk_extract" "$xkeen_archive"
-            return 1
-        fi
-
-        if [ ! -f "$_xk_extract/xkeen" ] || [ ! -d "$_xk_extract/_xkeen" ]; then
+        if ! tar -xzf "$xkeen_archive" -C "$stage_dir" xkeen _xkeen \
+            || [ ! -f "$stage_dir/xkeen" ] || [ ! -d "$stage_dir/_xkeen" ]; then
             echo -e "  ${red}Ошибка${reset}: В архиве XKeen нет ожидаемых xkeen/_xkeen"
-            rm -rf "$_xk_extract" "$xkeen_archive"
+            rm -rf "$stage_dir" "$xkeen_archive"
             return 1
         fi
-
-        chmod +x "$_xk_extract/xkeen"
-        mv -f "$_xk_extract/xkeen" "$install_dir/xkeen"
-        rm -rf "$install_dir/.xkeen"
-        mv "$_xk_extract/_xkeen" "$install_dir/.xkeen"
-        rm -rf "$_xk_extract" "$xkeen_archive"
+        chmod +x "$stage_dir/xkeen"
+        mv "$stage_dir/xkeen" "$install_dir/xkeen.new" || { rm -rf "$stage_dir"; return 1; }
+        mv "$install_dir/xkeen.new" "$install_dir/xkeen" || { rm -rf "$stage_dir"; return 1; }
+        rm -rf "$install_dir/.xkeen.old"
+        [ -d "$install_dir/.xkeen" ] && mv "$install_dir/.xkeen" "$install_dir/.xkeen.old"
+        if mv "$stage_dir/_xkeen" "$install_dir/.xkeen"; then
+            rm -rf "$install_dir/.xkeen.old" "$stage_dir"
+        else
+            [ -d "$install_dir/.xkeen.old" ] && mv "$install_dir/.xkeen.old" "$install_dir/.xkeen"
+            rm -rf "$stage_dir"
+            return 1
+        fi
     fi
     [ -d "$log_dir/xkeen" ] && rm -rf "$log_dir/xkeen"
     return 0

--- a/scripts/_xkeen/02_install/07_install_register/02_register_xkeen.sh
+++ b/scripts/_xkeen/02_install/07_install_register/02_register_xkeen.sh
@@ -119,6 +119,7 @@ register_autostart() {
 
 # Создание конфигурации XKeen
 create_xkeen_cfg() {
+    previous_umask=$(umask)
     umask 077
     mkdir -p "$xkeen_cfg" || { echo "Ошибка: Не удалось создать директорию $xkeen_cfg"; exit 1; }
     chmod 700 "$xkeen_cfg" 2>/dev/null
@@ -158,4 +159,5 @@ EOF
 EOF
     fi
     chmod 600 "$xkeen_config" 2>/dev/null
+    umask "$previous_umask"
 }

--- a/scripts/_xkeen/02_install/07_install_register/02_register_xkeen.sh
+++ b/scripts/_xkeen/02_install/07_install_register/02_register_xkeen.sh
@@ -119,7 +119,9 @@ register_autostart() {
 
 # Создание конфигурации XKeen
 create_xkeen_cfg() {
+    umask 077
     mkdir -p "$xkeen_cfg" || { echo "Ошибка: Не удалось создать директорию $xkeen_cfg"; exit 1; }
+    chmod 700 "$xkeen_cfg" 2>/dev/null
     if [ -f "/opt/etc/xkeen_exclude.lst" ] && [ ! -f "$file_ip_exclude" ]; then
         mv "/opt/etc/xkeen_exclude.lst" "$file_ip_exclude"
     elif [ ! -f "$file_ip_exclude" ]; then
@@ -155,4 +157,5 @@ EOF
 }
 EOF
     fi
+    chmod 600 "$xkeen_config" 2>/dev/null
 }

--- a/scripts/_xkeen/02_install/07_install_register/03_register_cron.sh
+++ b/scripts/_xkeen/02_install/07_install_register/03_register_cron.sh
@@ -97,13 +97,12 @@ exit 0'
 # Обновление cron задач
 update_cron_geofile_task() {
     if [ -f "$cron_dir/$cron_file" ]; then
-        tmp_file="$cron_dir/${cron_file}.tmp"
-        cp "$cron_dir/$cron_file" "$tmp_file"
-        
+        tmp_file="$cron_dir/${cron_file}.tmp.$$"
         if [ -z "$choice_cancel_cron_select" ]; then
-            grep -v -e "ug" -e "ux" -e "uk" -e '^\s*$' "$tmp_file" > "$cron_dir/$cron_file"
+            grep -v -E "($install_dir/xkeen[[:space:]]+-(ug|ux|uk))" "$cron_dir/$cron_file" > "$tmp_file"
         else
-            grep -v -e "ugi" -e "ugs" -e "ux" -e "uk" -e '^\s*$' "$tmp_file" > "$cron_dir/$cron_file"
+            grep -v -E "($install_dir/xkeen[[:space:]]+-(ugi|ugs|ux|uk))" "$cron_dir/$cron_file" > "$tmp_file"
         fi
+        mv -f "$tmp_file" "$cron_dir/$cron_file" || rm -f "$tmp_file"
     fi
 }

--- a/scripts/xkeen
+++ b/scripts/xkeen
@@ -628,6 +628,8 @@ while [ $# -gt 0 ]; do
             migrate_ports_from_initd
             register_xkeen_initd
             create_xkeen_cfg
+            chmod 700 "$xkeen_cfg" 2>/dev/null
+            chmod 600 "$xkeen_config" 2>/dev/null
             choice_cancel_cron_select=true
             update_cron_geofile_task
             smart_clear


### PR DESCRIPTION
## Что и зачем
- `install.sh` и `install_xkeen` ставят через stage + `.old`-танец — обрыв не оставляет полуустановку (и не сносит живой `.xkeen` до готовности нового).
- `xkeen.json` / каталог конфига — `600`/`700` (там RCI-токен); на `-uk` права дожимаются идемпотентно.
- Перезапись crontab матчит только полные команды `xkeen -ug|-ux|-uk`, пишет через tmp+mv — чужие cron-строки больше не сносит.

## Как проверял
На роутере Keenetic в составе `hardening/combined-all`: установка/апгрейд, права на конфиг, cron; `sh -n`.

**Часть 3/6** — можно параллельно с 2/4 после части 1 (независима от secure-rundir).

---
Часть стека харденинга. Полный порядок влития: **1 secure-rundir → 2 download-integrity → 3 atomic/secrets/cron → 4 proxy-lifecycle → 5 killswitch → 6 hook/boot**. Проверено суммарно в `hardening/combined-all`.

Made with [Cursor](https://cursor.com)