### PR TITLE
feat: opt-in kill-switch and last-good policy mark cache

### DIFF
--- a/scripts/_xkeen/02_install/07_install_register/04_register_init.sh
+++ b/scripts/_xkeen/02_install/07_install_register/04_register_init.sh
@@ -3473,6 +3473,7 @@ enable_killswitch() {
             printf ':%s_killswitch -\n' "$name_chain"
             for _ks_mark in $_ks_marks; do
                 [ -n "$_ks_mark" ] || continue
+                printf '%s\n' "-A ${name_chain}_killswitch -m conntrack ! --ctstate INVALID -m mark --mark ${_ks_mark} $comment -j DROP"
                 printf '%s\n' "-A ${name_chain}_killswitch -m conntrack ! --ctstate INVALID -m connmark --mark ${_ks_mark} $comment -j DROP"
             done
             printf '%s\n' "-A PREROUTING $comment -j ${name_chain}_killswitch"

--- a/scripts/_xkeen/02_install/07_install_register/04_register_init.sh
+++ b/scripts/_xkeen/02_install/07_install_register/04_register_init.sh
@@ -3474,7 +3474,6 @@ enable_killswitch() {
             for _ks_mark in $_ks_marks; do
                 [ -n "$_ks_mark" ] || continue
                 printf '%s\n' "-A ${name_chain}_killswitch -m conntrack ! --ctstate INVALID -m mark --mark ${_ks_mark} $comment -j DROP"
-                printf '%s\n' "-A ${name_chain}_killswitch -m conntrack ! --ctstate INVALID -m connmark --mark ${_ks_mark} $comment -j DROP"
             done
             printf '%s\n' "-A PREROUTING $comment -j ${name_chain}_killswitch"
             printf 'COMMIT\n'

--- a/scripts/_xkeen/02_install/07_install_register/04_register_init.sh
+++ b/scripts/_xkeen/02_install/07_install_register/04_register_init.sh
@@ -202,6 +202,17 @@ get_rci_token() {
 }
 get_rci_token
 
+# Fail closed is deliberately opt-in.  Old configurations remain fail-open.
+load_killswitch_settings() {
+    killswitch="off"
+    [ -f "$xkeen_config" ] || return 0
+    command -v jq >/dev/null 2>&1 || return 0
+    _ks_v=$(strip_json_comments "$xkeen_config" | jq -r '.xkeen.killswitch.enabled // false' 2>/dev/null)
+    [ "$_ks_v" = "true" ] && killswitch="on"
+    unset _ks_v
+}
+load_killswitch_settings
+
 # GOMEMLIMIT для mihomo: доля RAM или абсолютный лимит из xkeen.json.
 # Дефолт — 50% RAM (сохраняет прежнее поведение). Внешний
 # GOMEMLIMIT в окружении всегда побеждает.
@@ -2165,6 +2176,7 @@ EOL
     # GOMEMLIMIT для respawn mihomo внутри хука (вычислен при генерации)
     apply_gomemlimit
     inject_var gomemlimit_value "$gomemlimit_value"
+    inject_var killswitch "$killswitch"
 
     cat >> "$file_netfilter_hook" <<'EOL'
 
@@ -3179,6 +3191,12 @@ clean_firewall() {
             "$family" -w -t "$table" -F "$force_chain" >/dev/null 2>&1
             "$family" -w -t "$table" -X "$force_chain" >/dev/null 2>&1
         fi
+
+        killswitch_chain="${name_chain}_killswitch"
+        if "$family" -w -t "$table" -nL "$killswitch_chain" >/dev/null 2>&1; then
+            "$family" -w -t "$table" -F "$killswitch_chain" >/dev/null 2>&1
+            "$family" -w -t "$table" -X "$killswitch_chain" >/dev/null 2>&1
+        fi
     }
 
     for family in iptables ip6tables; do
@@ -3429,6 +3447,46 @@ _release_nf_lock() {
     fi
 }
 
+# Install an explicit fail-closed policy only after an unintentional core
+# failure.  Only traffic already selected by xkeen policy marks is dropped;
+# LAN/management and all unmarked traffic remain untouched.  The restore blob
+# is atomic and uses the same netfilter lock as normal cleanup.
+enable_killswitch() {
+    [ "$killswitch" = "on" ] || return 0
+    _ks_marks="$policy_mark $policy_mark_full"
+    if [ -n "$user_policies" ]; then
+        _ks_user_marks=$(printf '%s\n' "$user_policies" | awk -F'|' '$2 != "" {print "0x"$2}')
+        _ks_marks="$_ks_marks $_ks_user_marks"
+    fi
+    [ -n "$(printf '%s' "$_ks_marks" | tr -d ' ')" ] || {
+        log_warning_router "Kill-switch не установлен: нет policy-mark для безопасной выборки трафика"
+        return 1
+    }
+
+    _acquire_nf_lock || return 1
+    for _ks_family in iptables ip6tables; do
+        if [ "$_ks_family" = "iptables" ] && [ "$iptables_supported" != "true" ]; then continue; fi
+        if [ "$_ks_family" = "ip6tables" ] && [ "$ip6tables_supported" != "true" ]; then continue; fi
+        _ks_restore="${_ks_family}-restore"
+        _ks_blob=$( {
+            printf '*mangle\n'
+            printf ':%s_killswitch -\n' "$name_chain"
+            for _ks_mark in $_ks_marks; do
+                [ -n "$_ks_mark" ] || continue
+                printf '%s\n' "-A ${name_chain}_killswitch -m conntrack ! --ctstate INVALID -m connmark --mark ${_ks_mark} $comment -j DROP"
+            done
+            printf '%s\n' "-A PREROUTING $comment -j ${name_chain}_killswitch"
+            printf 'COMMIT\n'
+        } )
+        printf '%s' "$_ks_blob" | "$_ks_restore" --noflush || {
+            _release_nf_lock
+            return 1
+        }
+    done
+    _release_nf_lock
+    log_warning_router "Kill-switch включён: трафик политики xkeen заблокирован до явного stop/start"
+}
+
 # Очистка при аварийной остановке прокси-клиента
 emergency_clear() {
     _acquire_proxy_mutex
@@ -3441,6 +3499,7 @@ emergency_clear() {
     _release_coldstart_guard
     cleanup_fd_monitor
     clean_firewall
+    enable_killswitch
     if [ "$_ec_mutex_rc" -eq 0 ]; then
         _release_proxy_mutex
     fi
@@ -3642,6 +3701,8 @@ proxy_start() {
                 attempt=$((attempt + 1))
             done
             echo -e "  ${red}Не удалось запустить${reset} прокси-клиент"
+            clean_firewall
+            enable_killswitch
             log_error_terminal "Не удалось запустить прокси-клиент"
             _release_coldstart_guard
         fi

--- a/scripts/_xkeen/02_install/07_install_register/04_register_init.sh
+++ b/scripts/_xkeen/02_install/07_install_register/04_register_init.sh
@@ -3526,6 +3526,19 @@ proxy_start() {
         check_xray_backups
         api_cache_init
         policy_mark=$(get_policy_mark "$name_policy")
+        policy_mark_cache="$xkeen_cfg/.last_policy_mark"
+        if [ -n "$policy_mark" ]; then
+            _pm_tmp="${policy_mark_cache}.tmp.$$"
+            (umask 077; printf '%s\n' "$policy_mark" > "$_pm_tmp") &&
+                chmod 600 "$_pm_tmp" && mv -f "$_pm_tmp" "$policy_mark_cache"
+        elif [ -s "$policy_mark_cache" ]; then
+            _cached_mark=$(cat "$policy_mark_cache" 2>/dev/null)
+            case "$_cached_mark" in
+                0x[0-9A-Fa-f]*) policy_mark="$_cached_mark"; log_warning_router "RCI не вернул mark xkeen; используется последний успешный mark" ;;
+            esac
+        else
+            log_warning_router "RCI не вернул mark xkeen; без policy-mark будет применён явный режим проксирования всех"
+        fi
         policy_mark_full=$(get_policy_mark "$name_policy_full")
         user_policies=$(resolve_user_policies)
         validate_entware_proxy_mark

--- a/scripts/_xkeen/04_tools/05_tools_choice/02_choice_xkeen.sh
+++ b/scripts/_xkeen/04_tools/05_tools_choice/02_choice_xkeen.sh
@@ -258,6 +258,30 @@ change_pbr_strict() {
     toggle_param "pbr_strict" "strict PBR-проверки для исходящих подключений Xray/Mihomo" "restart" "$1"
 }
 
+change_killswitch() {
+    state="$1"
+    [ "$state" = "on" ] || [ "$state" = "off" ] || return 1
+    [ -f "$xkeen_config" ] || { echo -e "  ${red}Ошибка${reset}: не найден xkeen.json"; return 1; }
+    command -v jq >/dev/null 2>&1 || { echo -e "  ${red}Ошибка${reset}: требуется jq"; return 1; }
+    tmp="${xkeen_config}.tmp.$$"
+    if strip_json_comments "$xkeen_config" | jq --argjson enabled "$([ "$state" = on ] && echo true || echo false)" \
+        '.xkeen = (.xkeen // {}) | .xkeen.killswitch = (.xkeen.killswitch // {}) | .xkeen.killswitch.enabled = $enabled' > "$tmp" \
+        && chmod 600 "$tmp" && mv -f "$tmp" "$xkeen_config"; then
+        echo -e "  Kill-switch ${green}${state}${reset}"
+        register_xkeen_initd
+    else
+        rm -f "$tmp"
+        echo -e "  ${red}Ошибка${reset}: не удалось сохранить настройку kill-switch"
+        return 1
+    fi
+}
+
+show_killswitch_status() {
+    state="off"
+    [ -f "$xkeen_config" ] && state=$(strip_json_comments "$xkeen_config" | jq -r '.xkeen.killswitch.enabled // false' 2>/dev/null)
+    [ "$state" = "true" ] && echo -e "  Kill-switch: ${green}включён${reset}" || echo -e "  Kill-switch: ${red}выключен${reset}"
+}
+
 _pbr_hex_to_decimal() {
     mark="$1"
     mark="${mark#0x}"

--- a/scripts/_xkeen/about.sh
+++ b/scripts/_xkeen/about.sh
@@ -84,6 +84,7 @@ help_xkeen() {
     echo -e "	-dns		${italic}Включить | Отключить перенаправление DNS в прокси${reset}"
     echo -e "	-pr		${italic}Включить | Отключить проксирование трафика Entware через Xray/Mihomo${reset}"
     echo -e "	-pbr		${italic}Strict PBR-проверка mark / routing-mark для Xray/Mihomo: on | off | status | codes${reset}"
+    echo -e "	-killswitch	${italic}Блокировать трафик policy xkeen при аварии ядра: on | off | status${reset}"
     echo -e "	-startvb	${italic}Включить | Отключить вывод информации при старте прокси-клиента${reset}"
     echo -e "	-extmsg		${italic}Включить | Отключить расширенные сообщения при запуске XKeen${reset}"
     echo -e "	-cbk		${italic}Включить | Отключить резервное копирование XKeen при обновлении${reset}"

--- a/scripts/xkeen
+++ b/scripts/xkeen
@@ -1544,6 +1544,25 @@ while [ $# -gt 0 ]; do
             esac
         ;;
 
+        -killswitch)
+            case "$2" in
+                on|off)
+                    smart_clear
+                    change_killswitch "$2"
+                    shift
+                    ;;
+                status)
+                    smart_clear
+                    show_killswitch_status
+                    shift
+                    ;;
+                *)
+                    echo -e "  ${red}Ошибка${reset}: используйте ${yellow}xkeen -killswitch on${reset}, ${yellow}off${reset} или ${yellow}status${reset}"
+                    exit 1
+                    ;;
+            esac
+        ;;
+
 
         -extmsg)    # Включение/отключение расширенных сообщений запуска XKeen
             action=$(get_state_arg "$2")

--- a/wiki/Конфигурационный-файл.md
+++ b/wiki/Конфигурационный-файл.md
@@ -9,6 +9,9 @@
     "gh_proxy": "",
     "retries_download": "",
     "retry_delay_download": "",
+    "killswitch": {
+      "enabled": false
+    },
     "speed_balancer": {
       "enabled": false
     },
@@ -44,6 +47,7 @@
 - `gh_proxy` - пользовательский прокси для загрузок с GitHub (пример `"gh_proxy": "https://ghproxy.me",`)
 - `retries_download` - количество повторных попыток загрузки с GitHub (пример `"retries_download": "3",`)
 - `retry_delay_download` - количество секунд между попытками повторных загрузок (пример `"retry_delay_download": "10",`)
+- `killswitch.enabled` - при `true` после аварийного падения ядра блокирует только трафик, помеченный политикой XKeen, вместо его прямой утечки. По умолчанию `false`; явный `xkeen -stop` всегда снимает блокировку. При включении убедитесь, что у вас есть доступ к роутеру для выполнения `xkeen -stop`.
 - `speed_balancer` - балансировщик xray по фактической скорости серверов ([подробнее](https://github.com/jameszeroX/XKeen/wiki/Configuration#балансировка-по-фактической-скорости))
 - `policy` - раздел, описывающий пользовательские политики маршрутизации
 - `xkeen0` - пользовательская политика, проксирование на всех портах (имя политики произвольное)


### PR DESCRIPTION
## Что и зачем
- Opt-in kill-switch (`.xkeen.killswitch.enabled`, CLI `xkeen -killswitch on|off|status`): при аварии ядра дропает только помеченный политикой трафик вместо прямой утечки. Дефолт **off** — старые установки не меняются. Явный `xkeen -stop` снимает блокировку полностью.
- Кэш последнего успешного policy mark: при глюке RCI не скатываемся в «прокси для всех», а берём last-good с warning.
- В DROP матчим packet-mark (connmark после сноса save-mark цепочки на железе не срабатывал).

## Как проверял
На роутере Keenetic (mihomo/TProxy) в составе `hardening/combined-all`: killswitch on → kill ядра → дроп помеченного трафика, LAN/морда живы; `xkeen -stop` снимает; `sh -n`.

**Часть 5/6** — после части 1.

---
Часть стека харденинга. Полный порядок влития: **1 secure-rundir → 2 download-integrity → 3 atomic/secrets/cron → 4 proxy-lifecycle → 5 killswitch → 6 hook/boot**. Ветка включает коммиты предыдущих частей — diff очистится после их мержа. Проверено суммарно в `hardening/combined-all`.

Made with [Cursor](https://cursor.com)