### PR TITLE
fix: refill empty geo sets and tolerate empty policy API on boot

### DIFF
--- a/scripts/_xkeen/02_install/07_install_register/04_register_init.sh
+++ b/scripts/_xkeen/02_install/07_install_register/04_register_init.sh
@@ -2917,6 +2917,26 @@ USER_POLICIES_EOF
         return 0
     }
 
+    # OOM can leave an existing geo set empty even though its list is valid.
+    # Refill only the broken state, keeping ordinary renews inexpensive.
+    _xkeen_refill_geo_if_empty() {
+        _rg_set="$1"
+        _rg_file="$2"
+        _rg_family="$3"
+        [ -s "$_rg_file" ] || return 0
+        ipset save "$_rg_set" 2>/dev/null | grep -q '^add ' && return 0
+        _rg_tmp="${_rg_set}_renew_tmp"
+        ipset create "$_rg_tmp" hash:net family "$_rg_family" -exist 2>/dev/null || return 1
+        ipset flush "$_rg_tmp" 2>/dev/null
+        if sed -e 's/\r$//' -e 's/#.*//' -e '/^[[:space:]]*$/d' "$_rg_file" | \
+             awk '{print "add '"$_rg_tmp"' "$1}' | ipset restore -exist; then
+            ipset swap "$_rg_set" "$_rg_tmp" 2>/dev/null || return 1
+        else
+            logger -p daemon.warning -t xkeen "не удалось восстановить $_rg_set из $_rg_file"
+        fi
+        ipset destroy "$_rg_tmp" 2>/dev/null
+    }
+
     # Текущий WAN IPv4 (тот же способ, что get_exclude_ip4 при генерации).
     # На коротком DHCP lease (MGTS ~300 с) renew приходит каждые ~150 с
     # с тем же IP: NDM всё равно зовёт netfilter.d. Если IP не сменился
@@ -2930,6 +2950,8 @@ USER_POLICIES_EOF
     if [ -n "$_xkeen_cur_wan" ] && [ "$_xkeen_cur_wan" = "$_xkeen_prev_wan" ] && _xkeen_rules_intact; then
         # IP тот же, цепочки целы: deny-MAC обновляет schedule.d —
         # здесь curl под lock только мешает соседним событиям NDM.
+        [ "$iptables_supported" = "true" ] && _xkeen_refill_geo_if_empty geo_exclude "$ru_exclude_ipv4" inet
+        [ "$ip6tables_supported" = "true" ] && _xkeen_refill_geo_if_empty geo_exclude6 "$ru_exclude_ipv6" inet6
         _xkeen_release_nf_lock
         exit 0
     fi
@@ -2967,26 +2989,6 @@ USER_POLICIES_EOF
             ipset create geo_exclude6 hash:net family inet6 -exist 2>/dev/null
             ipset create geo_override6 hash:net family inet6 -exist 2>/dev/null
         fi
-    }
-
-    # OOM can leave an existing geo set empty even though its list is valid.
-    # On renew refill only that broken state; normal renews stay inexpensive.
-    _xkeen_refill_geo_if_empty() {
-        _rg_set="$1"
-        _rg_file="$2"
-        _rg_family="$3"
-        [ -s "$_rg_file" ] || return 0
-        ipset save "$_rg_set" 2>/dev/null | grep -q '^add ' && return 0
-        _rg_tmp="${_rg_set}_renew_tmp"
-        ipset create "$_rg_tmp" hash:net family "$_rg_family" -exist 2>/dev/null || return 1
-        ipset flush "$_rg_tmp" 2>/dev/null
-        if sed -e 's/\r$//' -e 's/#.*//' -e '/^[[:space:]]*$/d' "$_rg_file" | \
-             awk '{print "add '"$_rg_tmp"' "$1}' | ipset restore -exist; then
-            ipset swap "$_rg_set" "$_rg_tmp" 2>/dev/null || return 1
-        else
-            logger -p daemon.warning -t xkeen "не удалось восстановить $_rg_set из $_rg_file"
-        fi
-        ipset destroy "$_rg_tmp" 2>/dev/null
     }
 
     _xkeen_cache_valid() {

--- a/scripts/_xkeen/02_install/07_install_register/04_register_init.sh
+++ b/scripts/_xkeen/02_install/07_install_register/04_register_init.sh
@@ -2186,6 +2186,8 @@ EOL
     inject_var url_server "$url_server"
     inject_var url_hotspot "$url_hotspot"
     inject_var rci_token "$rci_token"
+    inject_var ru_exclude_ipv4 "$ru_exclude_ipv4"
+    inject_var ru_exclude_ipv6 "$ru_exclude_ipv6"
     # GOMEMLIMIT для respawn mihomo внутри хука (вычислен при генерации)
     apply_gomemlimit
     inject_var gomemlimit_value "$gomemlimit_value"
@@ -2967,6 +2969,26 @@ USER_POLICIES_EOF
         fi
     }
 
+    # OOM can leave an existing geo set empty even though its list is valid.
+    # On renew refill only that broken state; normal renews stay inexpensive.
+    _xkeen_refill_geo_if_empty() {
+        _rg_set="$1"
+        _rg_file="$2"
+        _rg_family="$3"
+        [ -s "$_rg_file" ] || return 0
+        ipset save "$_rg_set" 2>/dev/null | grep -q '^add ' && return 0
+        _rg_tmp="${_rg_set}_renew_tmp"
+        ipset create "$_rg_tmp" hash:net family "$_rg_family" -exist 2>/dev/null || return 1
+        ipset flush "$_rg_tmp" 2>/dev/null
+        if sed -e 's/\r$//' -e 's/#.*//' -e '/^[[:space:]]*$/d' "$_rg_file" | \
+             awk '{print "add '"$_rg_tmp"' "$1}' | ipset restore -exist; then
+            ipset swap "$_rg_set" "$_rg_tmp" 2>/dev/null || return 1
+        else
+            logger -p daemon.warning -t xkeen "не удалось восстановить $_rg_set из $_rg_file"
+        fi
+        ipset destroy "$_rg_tmp" 2>/dev/null
+    }
+
     _xkeen_cache_valid() {
         [ -s "$_xkeen_cache_dir/key" ] || return 1
         [ "$(cat "$_xkeen_cache_dir/key" 2>/dev/null)" = "$(md5sum "$0" 2>/dev/null | awk '{print $1}')" ]
@@ -3011,6 +3033,8 @@ USER_POLICIES_EOF
 
     if _xkeen_cache_valid; then
         _xkeen_ensure_ipsets
+        [ "$iptables_supported" = "true" ] && _xkeen_refill_geo_if_empty geo_exclude "$ru_exclude_ipv4" inet
+        [ "$ip6tables_supported" = "true" ] && _xkeen_refill_geo_if_empty geo_exclude6 "$ru_exclude_ipv6" inet6
         _xkeen_cache_load
         [ "$iptables_supported" = "true" ] && configure_route 4
         [ "$ip6tables_supported" = "true" ] && configure_route 6
@@ -3801,9 +3825,8 @@ wait_for_ready() {
             # Проверка готовности API политик и модуля xt_TPROXY
             api_policy_json=$(curl_api "${url_server}/${url_policy}" 2>/dev/null)
             case "$api_policy_json" in
-                ""|"{}")
-                    ;;
-                \{*)
+                ""|"{}"|"[]") return 0 ;;
+                \{*|\[*)
                     if [ -z "$_probe_ko" ] \
                        || grep -q '^xt_TPROXY ' /proc/modules 2>/dev/null \
                        || insmod "$_probe_ko" >/dev/null 2>&1


### PR DESCRIPTION
## Что и зачем
- После OOM `geo_exclude` может остаться пустым при живом `.lst` — renew раньше не перезаливал. Теперь точечно восстанавливаем только сломанный сет, в том числе на fast-path «WAN не менялся».
- `wait_for_ready` принимает и объект, и массив от RCI; пустой набор не гоняет полный таймаут.

Dry-run конфига ядра (`mihomo -t` / `xray run -test`) в этот MR **не входит** — на железе он ложно валил restart при долгом `-t`/обрыве WAN; из тестового `combined-all` его убрали.

## Как проверял
На роутере Keenetic (mihomo/TProxy) в составе `hardening/combined-all`: пустой geo + renew восстанавливает сет; cold boot; `sh -n`.

**Часть 6/6** — после части 5.

---
Часть стека харденинга. Полный порядок влития: **1 secure-rundir → 2 download-integrity → 3 atomic/secrets/cron → 4 proxy-lifecycle → 5 killswitch → 6 hook/boot**. Ветка включает коммиты предыдущих частей — diff очистится после их мержа. Проверено суммарно в `hardening/combined-all`.

Made with [Cursor](https://cursor.com)